### PR TITLE
Fix 404 on docs root

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -127,5 +127,11 @@
         ]
       }
     ]
-  }
+  },
+  "redirects": [
+    {
+      "source": "/",
+      "destination": "/introduction"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Add redirect from `/` to `/introduction` so the docs root URL doesn't 404