### PR TITLE
Fix empty sidebar: switch from tabs to flat groups navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -63,47 +63,41 @@
     }
   },
   "navigation": {
-    "tabs": [
+    "groups": [
       {
-        "tab": "Documentation",
-        "groups": [
+        "group": "Getting Started",
+        "pages": [
+          "introduction",
+          "install",
+          "cloud-vs-local"
+        ]
+      },
+      {
+        "group": "Features",
+        "pages": [
+          "track-usage",
+          "set-limits",
+          "routing"
+        ]
+      },
+      {
+        "group": "Reference",
+        "pages": [
+          "configuration",
+          "contributing"
+        ]
+      },
+      {
+        "group": "Links",
+        "pages": [
           {
-            "group": "Getting Started",
-            "pages": [
-              "introduction",
-              "install",
-              "cloud-vs-local"
-            ]
-          },
-          {
-            "group": "Features",
-            "pages": [
-              "track-usage",
-              "set-limits",
-              "routing"
-            ]
-          },
-          {
-            "group": "Reference",
-            "pages": [
-              "configuration",
-              "contributing"
-            ]
-          },
-          {
-            "group": "Links",
-            "pages": [
-              {
-                "title": "Homepage",
-                "icon": "globe",
-                "url": "https://manifest.build"
-              }
-            ]
+            "title": "Homepage",
+            "icon": "globe",
+            "url": "https://manifest.build"
           }
         ]
       }
-    ],
-    "global": {}
+    ]
   },
   "footer": {
     "socials": {


### PR DESCRIPTION
## Summary
- The sidebar navigation on manifest.build/docs is empty — no doc page links render
- Root cause: the `docs.json` uses a `tabs` navigation format with a single tab and empty `global: {}`, which Mintlify doesn't render correctly as sidebar nav
- Fix: switch to the simpler flat `groups` format that Mintlify traditionally uses for sidebar navigation

## Changes
- `docs.json`: replaced `navigation.tabs[0].groups` with `navigation.groups` (same groups/pages, just unwrapped from the tab)
- Removed empty `global: {}` object

## Test plan
- [ ] After merge, wait for Mintlify to rebuild
- [ ] Open manifest.build/docs — sidebar should show Getting Started, Features, Reference groups
- [ ] Verify all pages appear in sidebar: Introduction, Install, Cloud vs Local, Track Usage, Set Limits, Routing, Configuration, Contributing