### PR TITLE
Fix sidebar: use valid tabs navigation and remove invalid external link group

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -63,37 +63,32 @@
     }
   },
   "navigation": {
-    "groups": [
+    "tabs": [
       {
-        "group": "Getting Started",
-        "pages": [
-          "introduction",
-          "install",
-          "cloud-vs-local"
-        ]
-      },
-      {
-        "group": "Features",
-        "pages": [
-          "track-usage",
-          "set-limits",
-          "routing"
-        ]
-      },
-      {
-        "group": "Reference",
-        "pages": [
-          "configuration",
-          "contributing"
-        ]
-      },
-      {
-        "group": "Links",
-        "pages": [
+        "tab": "Documentation",
+        "groups": [
           {
-            "title": "Homepage",
-            "icon": "globe",
-            "url": "https://manifest.build"
+            "group": "Getting Started",
+            "pages": [
+              "introduction",
+              "install",
+              "cloud-vs-local"
+            ]
+          },
+          {
+            "group": "Features",
+            "pages": [
+              "track-usage",
+              "set-limits",
+              "routing"
+            ]
+          },
+          {
+            "group": "Reference",
+            "pages": [
+              "configuration",
+              "contributing"
+            ]
           }
         ]
       }

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Manifest"
-description: "Take control of your OpenClaw costs"
+description: "Take control of your OpenClaw costs."
 icon: "house"
 ---
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Manifest"
-description: "Take control of your OpenClaw costs."
+description: "Take control of your OpenClaw costs"
 icon: "house"
 ---
 


### PR DESCRIPTION
## Summary
- Root cause found: `mintlify validate` reveals the docs.json navigation was invalid
- The "Links" group had an external URL object as a page entry, which is not a valid page type in Mintlify's schema
- This caused the entire navigation to fail silently — the sidebar shell renders but with zero nav links
- Fix: use proper `tabs` format and remove the invalid "Links" group (homepage link already exists in logo href)

## Changes
- Switched navigation from flat `groups` back to `tabs` (the schema-validated format)
- Removed the "Links" group containing `{"title": "Homepage", "icon": "globe", "url": "..."}` — invalid page type
- Reverted trivial description change from previous trigger commit
- `mintlify validate` now passes successfully