### PR TITLE
Update README for Manifest documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,18 @@
-# Mintlify Starter Kit
+# Manifest Documentation
 
-Use the starter kit to get your docs deployed and ready to customize.
+Source for the [Manifest documentation site](https://manifest.build), built with [Mintlify](https://mintlify.com).
 
-Click the green **Use this template** button at the top of this repo to copy the Mintlify starter kit. The starter kit contains examples with
+Manifest is an open-source OpenClaw plugin that routes queries to the most cost-effective model and gives you a real-time dashboard to track tokens, costs, and usage.
 
-- Guide pages
-- Navigation
-- Customizations
-- API reference pages
-- Use of popular components
-
-**[Follow the full quickstart guide](https://starter.mintlify.com/quickstart)**
-
-## AI-assisted writing
-
-Set up your AI coding tool to work with Mintlify:
+## Local development
 
 ```bash
-npx skills add https://mintlify.com/docs
-```
-
-This command installs Mintlify's documentation skill for your configured AI tools like Claude Code, Cursor, Windsurf, and others. The skill includes component reference, writing standards, and workflow guidance.
-
-See the [AI tools guides](/ai-tools) for tool-specific setup.
-
-## Development
-
-Install the [Mintlify CLI](https://www.npmjs.com/package/mint) to preview your documentation changes locally. To install, use the following command:
-
-```
 npm i -g mint
-```
-
-Run the following command at the root of your documentation, where your `docs.json` is located:
-
-```
 mint dev
 ```
 
-View your local preview at `http://localhost:3000`.
+Then open `http://localhost:3000`.
 
-## Publishing changes
+## Contributing
 
-Install our GitHub app from your [dashboard](https://dashboard.mintlify.com/settings/organization/github-app) to propagate changes from your repo to your deployment. Changes are deployed to production automatically after pushing to the default branch.
-
-## Need help?
-
-### Troubleshooting
-
-- If your dev environment isn't running: Run `mint update` to ensure you have the most recent version of the CLI.
-- If a page loads as a 404: Make sure you are running in a folder with a valid `docs.json`.
-
-### Resources
-- [Mintlify documentation](https://mintlify.com/docs)
-
+Edit or add `.mdx` files and update `docs.json` for navigation. Changes pushed to the default branch are deployed automatically via the Mintlify GitHub app.


### PR DESCRIPTION
## Summary
Replaced the generic Mintlify starter kit README with project-specific documentation for the Manifest documentation site.

## Key Changes
- Updated title and introduction to reflect Manifest project instead of generic starter kit
- Added brief description of Manifest as an open-source OpenClaw plugin for cost-effective model routing
- Simplified development section with concise setup instructions
- Removed AI-assisted writing setup instructions (not applicable to this project)
- Removed generic Mintlify quickstart guide and troubleshooting sections
- Added Contributing section with guidance on editing `.mdx` files and updating `docs.json`
- Streamlined overall documentation to be project-focused rather than template-focused

## Notable Details
- Maintains reference to Mintlify as the underlying documentation platform
- Includes link to live documentation site (manifest.build)
- Provides clear local development workflow
- Clarifies contribution process for future maintainers

https://claude.ai/code/session_013SRsipaR9pwGUCXGtBtfwy