### PR TITLE
Replace Smart routing card with Fallbacks card on intro page

### DIFF
--- a/introduction.mdx
+++ b/introduction.mdx
@@ -9,8 +9,8 @@ Manifest is an open-source OpenClaw plugin that routes queries to the most cost-
 ## Why Manifest
 
 <CardGroup cols={3}>
-  <Card title="Smart routing" icon="split">
-    Scores each query across 23 dimensions and picks the cheapest model that can handle it. Saves up to 90%.
+  <Card title="Automatic fallbacks" icon="life-ring" href="/fallback">
+    If a model fails, Manifest retries with a backup model instantly — no downtime, no manual intervention.
   </Card>
   <Card title="Real-time dashboard" icon="chart-no-axes-combined">
     Track tokens, costs, messages, and model usage at a glance.


### PR DESCRIPTION
Swap the first card in the "Why Manifest" section to highlight automatic fallbacks and link to the new fallback docs page.

https://claude.ai/code/session_01TQkLYtoR3AHroKqxFHtKhY