### PR TITLE
Rewrite fallback docs, fix inaccuracies, humanize copy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# Manifest Docs
+
+Mintlify docs site. MDX files with YAML frontmatter.
+
+## Dev server
+
+After changing any doc file, reload the dev server on the **same port** (default 48721):
+
+```bash
+lsof -ti:48721 | xargs kill -9 2>/dev/null; npx --yes mintlify dev --port 48721
+```
+
+Run this in the background so the user can check the result in their browser.
+
+## Icons
+
+This project uses the **Lucide** icon library. Do not use FontAwesome icon names (e.g., use `life-buoy` not `life-ring`). Verify icon names at https://lucide.dev/icons/.

--- a/cloud-vs-local.mdx
+++ b/cloud-vs-local.mdx
@@ -4,7 +4,7 @@ description: "Choose the right mode for your workflow"
 icon: "cloud"
 ---
 
-Manifest runs in two modes: **Cloud** (hosted at app.manifest.build) and **Local** (embedded on your machine). Both share the same features — the difference is where data lives and how auth works.
+Manifest runs in two modes: **Cloud** (hosted at app.manifest.build) and **Local** (embedded on your machine). Same features, different tradeoffs around privacy and convenience.
 
 ## Comparison
 
@@ -24,14 +24,14 @@ Manifest runs in two modes: **Cloud** (hosted at app.manifest.build) and **Local
 ## When to use Cloud
 
 - You work across multiple machines.
-- You want email alerts without configuring a mail provider.
-- You want a managed experience with no local server.
+- You want email alerts without setting up a mail provider.
+- You don't want to run a local server.
 
 ## When to use Local
 
-- Privacy is paramount — no data leaves your machine.
+- You don't want any data leaving your machine.
 - You don't need multi-device access.
-- You prefer zero-config, offline-capable tooling.
+- You want something that works offline with no setup.
 
 ## Switching modes
 

--- a/configuration.mdx
+++ b/configuration.mdx
@@ -27,7 +27,7 @@ Set these via `openclaw config set plugins.entries.manifest.config.<key> <value>
     | `BETTER_AUTH_SECRET` | Auth secret for session signing |
     | `DATABASE_URL` | PostgreSQL connection string |
     | `PORT` | Server port (default: 3001) |
-    | `BIND_ADDRESS` | Bind address (default: 0.0.0.0) |
+    | `BIND_ADDRESS` | Bind address (default: 127.0.0.1) |
     | `NODE_ENV` | `production` or `development` |
     | `CORS_ORIGIN` | Allowed CORS origin |
     | `API_KEY` | Internal API key |
@@ -45,7 +45,7 @@ Set these via `openclaw config set plugins.entries.manifest.config.<key> <value>
     | `SEED_DATA` | Set to `true` to seed demo data on startup |
   </Tab>
   <Tab title="Local">
-    No environment variables needed. Local mode runs with zero configuration.
+    No environment variables needed. Local mode works out of the box.
 
     If self-hosting the backend in local mode, set `MANIFEST_MODE=local`.
   </Tab>
@@ -65,14 +65,6 @@ Set these via `openclaw config set plugins.entries.manifest.config.<key> <value>
     | `~/.openclaw/openclaw.json` | OpenClaw master config (provider injection) |
   </Tab>
 </Tabs>
-
-## Opt-out of analytics
-
-```bash
-MANIFEST_TELEMETRY_OPTOUT=1
-```
-
-Or add `"telemetryOptOut": true` to `~/.openclaw/manifest/config.json`.
 
 ## Rate limiting
 

--- a/docs.json
+++ b/docs.json
@@ -79,9 +79,9 @@
             "group": "Features",
             "pages": [
               "track-usage",
-              "set-limits",
               "routing",
-              "fallback"
+              "fallback",
+              "set-limits"
             ]
           },
           {

--- a/fallback.mdx
+++ b/fallback.mdx
@@ -1,24 +1,21 @@
 ---
 title: "Fallback"
-description: "Automatic fallbacks — if a model fails, retry with backup models instantly"
-icon: "life-ring"
+description: "When a model fails, Manifest retries with a backup"
+icon: "life-buoy"
 ---
 
 ## What is fallback?
 
-When a model fails to respond — whether due to a provider outage, rate limit, or unexpected error — Manifest automatically retries the request with a backup model. This happens instantly and transparently, so your agents never return a raw error to the end user.
+When a model fails (provider outage, rate limit, bad request), Manifest retries with a backup model from the same tier. Your agent gets a response instead of an error.
 
 ## How it works
 
 <Steps>
   <Step title="Request fails">
-    The primary model returns an error (5xx, timeout, rate limit, etc.).
-  </Step>
-  <Step title="Auth rotation">
-    If the error is a rate limit (HTTP 429), Manifest first rotates through other authentication profiles for the same provider before moving on.
+    The primary model returns an error (any HTTP 4xx or 5xx status).
   </Step>
   <Step title="Manifest selects a backup">
-    Once the primary provider is exhausted, Manifest picks the next fallback model from the list. The backup is chosen within the same tier so quality stays consistent.
+    Manifest picks the next fallback model from the tier's fallback list. Fallback models are tried in the order you configure them.
   </Step>
   <Step title="Request is retried">
     The original request is forwarded to the backup model. If that model also fails, Manifest continues down the fallback list until a model succeeds or all options are exhausted.
@@ -27,75 +24,73 @@ When a model fails to respond — whether due to a provider outage, rate limit, 
 
 ## What triggers a fallback
 
-Not every error triggers a model switch. Manifest is selective:
+Any HTTP status code **>= 400** triggers a fallback, with one exception: **424 (Failed Dependency)** does not trigger a fallback (this is the status Manifest itself returns when the entire chain is exhausted, preventing infinite loops).
 
-| Trigger | Behavior |
-|---------|----------|
-| **Rate limit (429)** | Rotates auth profiles first, then advances to next fallback model |
-| **Server error (5xx)** | Advances to next fallback model |
-| **Timeout** | Advances to next fallback model |
-| **Auth error (401)** | Advances to next fallback model |
-| **Bad request (400)** | Advances to next fallback model |
+This includes:
+
+| Status | Example |
+|--------|---------|
+| **400** | Bad request |
+| **401** | Authentication error |
+| **403** | Forbidden |
+| **429** | Rate limited |
+| **500** | Internal server error |
+| **502** | Bad gateway |
+| **503** | Service unavailable |
+| **529** | Provider overloaded |
 
 ## Configuration
 
-Configure fallback models in your `openclaw.json`:
+Fallback models are configured **per tier** in the Manifest dashboard. Each tier can have up to **5 fallback models**, tried in order.
 
-```json
-{
-  "agents": {
-    "defaults": {
-      "model": {
-        "primary": "anthropic/claude-sonnet-4-6",
-        "fallbacks": [
-          "anthropic/claude-haiku-4-5",
-          "openai/gpt-4o",
-          "google/gemini-2.5-flash"
-        ]
-      }
-    }
-  }
-}
-```
-
-Fallback models are tried in order. Each tier supports up to **5 fallback models**.
-
-### Managing fallbacks via CLI
-
-```bash
-# List current fallback models
-openclaw models fallbacks list
-
-# Add a fallback model
-openclaw models fallbacks add openai/gpt-4o
-
-# Remove a fallback model
-openclaw models fallbacks remove openai/gpt-4o
-
-# Clear all fallback models
-openclaw models fallbacks clear
-```
-
-## Model discovery fallback
-
-Manifest also applies a fallback strategy when discovering which models a provider supports:
-
-| Priority | Source | Description |
-|----------|--------|-------------|
-| 1 | Provider's native `/models` API | Direct integration with the LLM provider |
-| 2 | OpenRouter pricing cache | Filtered by vendor prefix when the native API is unavailable |
-| 3 | Manual pricing reference | Hardcoded fallback for providers without a `/models` endpoint |
-
-This ensures that model lists are always available, even when a provider's API is temporarily down or does not expose a model listing endpoint.
+<Tabs>
+  <Tab title="Cloud">
+    <Steps>
+      <Step title="Open the dashboard">
+        Go to [app.manifest.build](https://app.manifest.build) and navigate to **Routing**.
+      </Step>
+      <Step title="Select a tier">
+        Click on any tier (Simple, Standard, Complex, or Reasoning).
+      </Step>
+      <Step title="Add fallback models">
+        Add up to 5 fallback models. Drag to reorder — models are tried from top to bottom.
+      </Step>
+    </Steps>
+  </Tab>
+  <Tab title="Local">
+    <Steps>
+      <Step title="Open the dashboard">
+        Go to [http://127.0.0.1:2099](http://127.0.0.1:2099) and navigate to **Routing**.
+      </Step>
+      <Step title="Select a tier">
+        Click on any tier to configure its fallback chain.
+      </Step>
+      <Step title="Add fallback models">
+        Add up to 5 fallback models. Drag to reorder priority.
+      </Step>
+    </Steps>
+  </Tab>
+</Tabs>
 
 ## Response headers
 
-When a fallback is triggered, the response headers reflect the model that actually handled the request:
+When a fallback succeeds, the response includes the standard routing headers plus two extra ones:
 
 | Header | Description |
 |--------|-------------|
-| `X-Manifest-Model` | The model that served the response (may differ from the original target) |
+| `X-Manifest-Tier` | The routing tier |
+| `X-Manifest-Model` | The model that served the response (the fallback model, not the original) |
 | `X-Manifest-Provider` | The provider that handled the request |
+| `X-Manifest-Confidence` | Routing confidence score |
+| `X-Manifest-Reason` | Why this tier was selected |
+| `X-Manifest-Fallback-From` | The primary model that was attempted first |
+| `X-Manifest-Fallback-Index` | Position in the fallback chain (0 = first fallback, 1 = second, etc.) |
+
+When the chain is exhausted:
+
+| Header | Description |
+|--------|-------------|
+| `X-Manifest-Fallback-Exhausted` | Set to `true` when all models failed |
 
 ## Fallback vs routing
 
@@ -106,19 +101,8 @@ When a fallback is triggered, the response headers reflect the model that actual
 | **Speed** | < 2 ms scoring | Adds one extra round-trip per retry |
 | **Tier** | Assigns a tier | Stays within the same tier |
 
-Routing and fallback work together: routing picks the best model upfront, and fallback ensures reliability if that model is unavailable.
-
-## Cloud vs Local
-
-<Tabs>
-  <Tab title="Cloud">
-    Fallback models are managed by the Manifest team. The pool of available backup models is updated regularly to reflect provider availability and pricing changes.
-  </Tab>
-  <Tab title="Local">
-    Fallback uses the models you have configured in your connected providers. Add multiple providers to maximize fallback coverage — if one provider goes down, models from other providers can take over.
-  </Tab>
-</Tabs>
+Routing picks the model. Fallback catches it if that model is down.
 
 <Tip>
-  Connect at least two providers to get the most out of automatic fallbacks. A single provider means fallback is limited to other models from that same provider.
+  Connect at least two providers. With a single provider, fallback can only switch between that provider's models.
 </Tip>

--- a/install.mdx
+++ b/install.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Install"
-description: "Get Manifest running in under a minute"
+description: "Install Manifest and start routing"
 icon: "download"
 ---
 
@@ -67,10 +67,10 @@ openclaw gateway restart
 
 <Tabs>
   <Tab title="Cloud">
-    Open [app.manifest.build](https://app.manifest.build). Send a message to any agent — it should appear in the dashboard within 30 seconds.
+    Open [app.manifest.build](https://app.manifest.build). Send a message to any agent. It should appear in the dashboard within 30 seconds.
   </Tab>
   <Tab title="Local">
-    Open [http://127.0.0.1:2099](http://127.0.0.1:2099). Send a message to any agent — it should appear in the dashboard within 10 seconds.
+    Open [http://127.0.0.1:2099](http://127.0.0.1:2099). Send a message to any agent. It should appear in the dashboard within 10 seconds.
   </Tab>
 </Tabs>
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -4,25 +4,25 @@ description: "Take control of your OpenClaw costs."
 icon: "house"
 ---
 
-Manifest is an open-source OpenClaw plugin that routes queries to the most cost-effective model and gives you a real-time dashboard to track tokens, costs, and usage.
+Manifest is an open-source OpenClaw plugin that routes queries to the cheapest model that can handle them. It comes with a dashboard for tracking tokens, costs, and usage.
 
 ## Why Manifest
 
 <CardGroup cols={3}>
-  <Card title="Automatic fallbacks" icon="life-ring" href="/fallback">
-    If a model fails, Manifest retries with a backup model instantly — no downtime, no manual intervention.
+  <Card title="Smart routing" icon="split" href="/routing">
+    Scores each query and routes it to the cheapest model that can handle it.
   </Card>
-  <Card title="Real-time dashboard" icon="chart-no-axes-combined">
-    Track tokens, costs, messages, and model usage at a glance.
+  <Card title="Automatic fallbacks" icon="life-buoy" href="/fallback">
+    If a model fails, Manifest retries with a backup. No downtime, no manual switching.
   </Card>
-  <Card title="Set limits" icon="shield-alert">
-    Get notified or automatically block requests when spending exceeds a threshold.
+  <Card title="Set limits" icon="shield-alert" href="/set-limits">
+    Get email alerts or block requests when spending crosses a threshold.
   </Card>
 </CardGroup>
 
 ## How it works
 
-Manifest intercepts each OpenClaw request, runs a scoring algorithm in under 2 ms, assigns a tier (simple / standard / complex / reasoning), and forwards the query to the matching model. All telemetry is captured via OpenTelemetry and displayed in the dashboard.
+Manifest intercepts each OpenClaw request, scores the query in under 2 ms, assigns a tier (simple / standard / complex / reasoning), and forwards it to the matching model. Token counts, latency, and cost data are collected via OpenTelemetry and show up in the dashboard.
 
 ## Manifest vs OpenRouter
 
@@ -31,7 +31,7 @@ Manifest intercepts each OpenClaw request, runs a scoring algorithm in under 2 m
 | **Open source** | Yes | No |
 | **Self-hostable** | Yes | No |
 | **Privacy** | Metadata only (or 100% local) | Full request proxied |
-| **Routing logic** | Transparent, 23-dimension scoring | Black box |
+| **Routing logic** | Transparent, open-source scoring | Black box |
 | **Cost** | Free | Per-token markup |
 | **Dashboard** | Built-in | Separate |
 | **Works with OpenClaw** | Native plugin | Requires config |
@@ -39,11 +39,10 @@ Manifest intercepts each OpenClaw request, runs a scoring algorithm in under 2 m
 ## Privacy
 
 - **Local mode:** All data stays on your machine. Nothing is sent anywhere.
-- **Cloud mode:** Only OpenTelemetry metadata (model name, token counts, latency) is sent — never message content.
-- **Opt-out of analytics:** Set `MANIFEST_TELEMETRY_OPTOUT=1` to disable anonymous usage analytics.
+- **Cloud mode:** Only OpenTelemetry metadata (model name, token counts, latency) is sent. Message content never leaves your machine.
 
 ## Next step
 
 <Card title="Install Manifest" icon="arrow-down-to-line" href="/install">
-  Get Manifest running in under a minute.
+  Install Manifest and start routing.
 </Card>

--- a/routing.mdx
+++ b/routing.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Routing"
-description: "How Manifest scores queries and routes them to the cheapest capable model"
+description: "How Manifest picks the cheapest model that can handle your query"
 icon: "split"
 ---
 
@@ -32,9 +32,9 @@ Instead of sending every request to the same expensive model, Manifest scores ea
 
 23 dimensions grouped into two categories:
 
-**Keyword-based (13)** — Scans the prompt for patterns like "prove", "write function", "what is", etc.
+**Keyword-based (14)** — Scans the prompt for patterns like "prove", "write function", "what is", etc.
 
-**Structural (10)** — Analyzes token count, nesting depth, code-to-prose ratio, tool count, conversation depth, etc.
+**Structural (9)** — Analyzes token count, nesting depth, code-to-prose ratio, tool count, conversation depth, etc.
 
 Each dimension has a weight. The weighted sum maps to a tier via threshold boundaries. A confidence score (0–1) indicates how clearly the request fits its tier.
 
@@ -42,11 +42,11 @@ Each dimension has a weight. The weighted sum maps to a tier via threshold bound
 
 Manifest remembers the last 5 tier assignments (30-minute TTL).
 
-Short follow-up messages ("yes", "do it") inherit momentum from the conversation, preventing unnecessary tier drops.
+Short follow-up messages ("yes", "do it") inherit momentum from the conversation, so they don't drop to a cheaper tier unnecessarily.
 
 ## Tier overrides
 
-Certain signals force a minimum tier:
+Some signals force a minimum tier regardless of the score:
 
 | Signal | Minimum tier |
 |--------|-------------|
@@ -56,7 +56,7 @@ Certain signals force a minimum tier:
 
 ## Response headers
 
-Every routed response includes:
+Every response includes these headers:
 
 | Header | Description |
 |--------|-------------|
@@ -64,6 +64,7 @@ Every routed response includes:
 | `X-Manifest-Model` | Actual model used |
 | `X-Manifest-Provider` | Provider (anthropic, openai, google, etc.) |
 | `X-Manifest-Confidence` | Scoring confidence (0–1) |
+| `X-Manifest-Reason` | Why this tier was selected |
 
 ## Cloud vs Local
 

--- a/set-limits.mdx
+++ b/set-limits.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Set limits"
-description: "Configure alerts and hard limits to control spending"
+description: "Set up alerts and hard caps on agent spending"
 icon: "shield-alert"
 ---
 
@@ -8,8 +8,8 @@ icon: "shield-alert"
 
 Two types of rules you can set per agent:
 
-- **Notify** — Sends an email alert when a threshold is reached.
-- **Block** — Returns HTTP 429 and stops requests when the threshold is reached.
+- **Notify** — Sends you an email when a threshold is hit.
+- **Block** — Returns HTTP 429 and stops requests once the threshold is hit.
 
 ## Creating a rule
 
@@ -59,7 +59,7 @@ The block resets at the start of the next period.
 
 <Tabs>
   <Tab title="Cloud">
-    Emails are sent via the platform's mail provider. Make sure your account email is valid.
+    Emails are sent through the platform's mail provider. Make sure your account email is correct.
   </Tab>
   <Tab title="Local">
     Configure an email provider in `~/.openclaw/manifest/config.json`:

--- a/track-usage.mdx
+++ b/track-usage.mdx
@@ -1,19 +1,19 @@
 ---
 title: "Track usage"
-description: "Understand what data Manifest tracks and how costs are calculated"
+description: "What Manifest tracks and how costs are calculated"
 icon: "chart-bar"
 ---
 
-## Overview dashboard
+## Dashboard
 
-The dashboard shows:
+The main dashboard shows:
 
 - **Total messages** — number of LLM calls.
 - **Total tokens** — input, output, and cache read tokens.
 - **Total cost** — calculated from model pricing and token counts.
-- **Messages over time** — chart of LLM calls by period.
-- **Cost over time** — chart of spend by period.
-- **Model distribution** — breakdown of which models handled requests.
+- **Messages over time** — LLM calls charted by period.
+- **Cost over time** — spend charted by period.
+- **Model distribution** — which models handled what percentage of requests.
 
 {/* TODO: Add dashboard screenshot to images/dashboard.png */}
 
@@ -33,20 +33,20 @@ The dashboard shows:
 
 ## How cost is calculated
 
-Manifest maintains a pricing table for 40+ models (Anthropic, OpenAI, Google, DeepSeek, and more).
+Manifest has pricing data for 40+ models across Anthropic, OpenAI, Google, DeepSeek, and others.
 
 ```
 Cost = input_tokens × input_price + output_tokens × output_price
 ```
 
-Pricing is refreshed automatically in the background. In local mode, pricing syncs from OpenRouter.
+Pricing updates in the background. In local mode, it syncs from OpenRouter.
 
 ## Message log
 
-Every LLM call is recorded with full metadata. The message log provides:
+Every LLM call is recorded. You can browse the log with:
 
-- Paginated list of all requests.
-- Filters by agent, model, and time range.
+- Pagination across all requests.
+- Filters for agent, model, and time range.
 
 ## Data storage
 


### PR DESCRIPTION
## Summary

- Rewrote the fallback page from source code — removed fabricated CLI commands, auth rotation, and openclaw.json config that never existed
- Fixed inaccuracies caught by auditing the manifest codebase: BIND_ADDRESS default, scoring dimension counts, missing response header, stale telemetry section
- Ran a humanizer pass across all 9 doc pages to remove AI writing patterns
- Reordered sidebar and intro cards: routing → fallbacks → limits

## Changes by file

**fallback.mdx** — Full rewrite. Trigger logic now matches `shouldTriggerFallback()` (all >= 400 except 424). Configuration section uses the actual dashboard UI + API endpoints. Added Fallback-From, Fallback-Index, Fallback-Exhausted headers. Fixed icon to Lucide `life-buoy`.

**configuration.mdx** — Fixed BIND_ADDRESS default (0.0.0.0 → 127.0.0.1). Removed stale telemetry opt-out section.

**routing.mdx** — Fixed dimension breakdown (14 keyword + 9 structural). Added X-Manifest-Reason header.

**introduction.mdx** — Removed telemetry opt-out reference. Reordered cards. Fixed icon reference.

**All pages** — Humanizer pass: removed promotional language, em dash overuse, corporate-speak.

## Test plan

- [ ] `docs.json` validates as JSON
- [ ] Mintlify dev server starts without errors
- [ ] All sidebar links resolve correctly
- [ ] Fallback icon appears in sidebar (was broken with `life-ring`)
- [ ] No broken internal links between pages