### PR TITLE
Update docs for manifest/manifest-provider plugin split

### DIFF
--- a/cloud-vs-local.mdx
+++ b/cloud-vs-local.mdx
@@ -1,16 +1,17 @@
 ---
 title: "Cloud vs Local"
-description: "Choose the right mode for your workflow"
+description: "Choose the right plugin for your workflow"
 icon: "cloud"
 ---
 
-Manifest runs in two modes: **Cloud** (hosted at app.manifest.build) and **Local** (embedded on your machine). Same features, different tradeoffs around privacy and convenience.
+Manifest ships as two plugins: **manifest-provider** (cloud, hosted at app.manifest.build) and **manifest** (self-hosted, runs on your machine). Same routing and dashboard, different tradeoffs on privacy and convenience.
 
 ## Comparison
 
-| | Cloud | Local |
+| | Cloud (`manifest-provider`) | Local (`manifest`) |
 |---|---|---|
 | **Setup** | Sign up + API key | Zero config |
+| **Package size** | ~22 KB | ~50 MB |
 | **Data storage** | PostgreSQL (hosted) | SQLite on your machine |
 | **Dashboard** | app.manifest.build | http://127.0.0.1:2099 |
 | **Auth** | Email/password or OAuth (Google, GitHub, Discord) | Auto-login (loopback trust) |
@@ -33,17 +34,17 @@ Manifest runs in two modes: **Cloud** (hosted at app.manifest.build) and **Local
 - You don't need multi-device access.
 - You want something that works offline with no setup.
 
-## Switching modes
+## Switching plugins
 
 ```bash
 # Switch to cloud
-openclaw config set plugins.entries.manifest.config.mode cloud
-openclaw config set plugins.entries.manifest.config.apiKey "mnfst_YOUR_KEY"
+openclaw plugins install manifest-provider
+openclaw providers setup manifest-provider
 openclaw gateway restart
 
 # Switch to local
-openclaw config set plugins.entries.manifest.config.mode local
+openclaw plugins install manifest
 openclaw gateway restart
 ```
 
-<Warning>Switching modes does not migrate data. Cloud and local have separate databases.</Warning>
+<Warning>Switching does not migrate data. Cloud and local have separate databases.</Warning>

--- a/configuration.mdx
+++ b/configuration.mdx
@@ -4,17 +4,25 @@ description: "All settings reference for Manifest"
 icon: "settings"
 ---
 
-## Plugin settings
+## manifest (self-hosted)
 
-Set these via `openclaw config set plugins.entries.manifest.config.<key> <value>`.
+Set via `openclaw config set plugins.entries.manifest.config.<key> <value>`.
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `mode` | `string` | `local` | `local`, `cloud`, or `dev` |
-| `apiKey` | `string` | — | OTLP key (`mnfst_...`). Required for cloud. Auto-generated for local. |
-| `endpoint` | `string` | `https://app.manifest.build/otlp` | OTLP endpoint. Only used in cloud/dev. |
-| `port` | `number` | `2099` | Dashboard port (local only). |
-| `host` | `string` | `127.0.0.1` | Bind address (local only). |
+| `port` | `number` | `2099` | Embedded server port |
+| `host` | `string` | `127.0.0.1` | Bind address |
+
+## manifest-provider (cloud)
+
+Set via `openclaw config set plugins.entries.manifest-provider.config.<key> <value>`.
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `devMode` | `boolean` | auto | Skip API key validation. Auto-detected when the endpoint is a loopback address. |
+| `endpoint` | `string` | `https://app.manifest.build` | Manifest server URL |
+
+API key is set via `openclaw providers setup manifest-provider` (interactive) or the `MANIFEST_API_KEY` environment variable.
 
 ## Environment variables
 

--- a/contributing.mdx
+++ b/contributing.mdx
@@ -14,6 +14,17 @@ icon: "git-pull-request"
 | Auth | Better Auth |
 | Build | Turborepo |
 
+## Project structure
+
+```
+packages/
+├── backend/              # NestJS API server
+├── frontend/             # SolidJS dashboard
+└── openclaw-plugins/
+    ├── manifest/          # npm: manifest — self-hosted plugin (embedded server + dashboard)
+    └── manifest-provider/ # npm: manifest-provider — cloud-only provider plugin
+```
+
 ## Prerequisites
 
 - Node.js 22.x
@@ -100,6 +111,10 @@ npm run test:e2e --workspace=packages/backend
 
 # Vitest frontend tests
 npm test --workspace=packages/frontend
+
+# Plugin tests
+npm test --workspace=packages/openclaw-plugins/manifest
+npm test --workspace=packages/openclaw-plugins/manifest-provider
 ```
 
 ## Database migrations

--- a/install.mdx
+++ b/install.mdx
@@ -18,13 +18,7 @@ icon: "download"
   </Tab>
 </Tabs>
 
-## Install the plugin
-
-```bash
-openclaw plugins install manifest
-```
-
-## Configure mode
+## Install
 
 <Tabs>
   <Tab title="Cloud">
@@ -38,16 +32,44 @@ openclaw plugins install manifest
       <Step title="Copy your API key">
         Copy the generated API key (`mnfst_...`).
       </Step>
-      <Step title="Configure the plugin">
+      <Step title="Install the plugin">
         ```bash
-        openclaw config set plugins.entries.manifest.config.mode cloud
-        openclaw config set plugins.entries.manifest.config.apiKey "mnfst_YOUR_KEY"
+        openclaw plugins install manifest-provider
+        ```
+      </Step>
+      <Step title="Set up your API key">
+        ```bash
+        openclaw providers setup manifest-provider
+        ```
+        This prompts you for the API key interactively.
+
+        In CI/CD, set the key as an environment variable instead:
+        ```bash
+        export MANIFEST_API_KEY=mnfst_YOUR_KEY
+        ```
+      </Step>
+      <Step title="Restart the gateway">
+        ```bash
+        openclaw gateway restart
         ```
       </Step>
     </Steps>
   </Tab>
   <Tab title="Local">
-    No configuration needed. Local mode is the default.
+    <Steps>
+      <Step title="Install the plugin">
+        ```bash
+        openclaw plugins install manifest
+        ```
+      </Step>
+      <Step title="Restart the gateway">
+        ```bash
+        openclaw gateway restart
+        ```
+      </Step>
+    </Steps>
+
+    No configuration needed. Local mode works out of the box.
 
     Optionally change the dashboard port:
 
@@ -56,12 +78,6 @@ openclaw plugins install manifest
     ```
   </Tab>
 </Tabs>
-
-## Restart the gateway
-
-```bash
-openclaw gateway restart
-```
 
 ## Verify
 
@@ -74,4 +90,4 @@ openclaw gateway restart
   </Tab>
 </Tabs>
 
-<Info>The gateway batches telemetry every 10–30 seconds. New messages may take a moment to appear.</Info>
+<Info>The gateway batches telemetry every 10-30 seconds. New messages may take a moment to appear.</Info>

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -38,8 +38,8 @@ Manifest intercepts each OpenClaw request, scores the query in under 2 ms, assig
 
 ## Privacy
 
-- **Local mode:** All data stays on your machine. Nothing is sent anywhere.
-- **Cloud mode:** Only OpenTelemetry metadata (model name, token counts, latency) is sent. Message content never leaves your machine.
+- **Local plugin (`manifest`):** All data stays on your machine. Nothing is sent anywhere.
+- **Cloud plugin (`manifest-provider`):** Only OpenTelemetry metadata (model name, token counts, latency) is sent. Message content never leaves your machine.
 
 ## Next step
 


### PR DESCRIPTION
## Summary

- **install.mdx**: Cloud setup now installs `manifest-provider` and uses `openclaw providers setup` for API key auth. Local setup installs `manifest` directly.
- **configuration.mdx**: Split settings into two plugin sections (`manifest` for self-hosted, `manifest-provider` for cloud). Removed deprecated `mode` and `apiKey` config keys.
- **cloud-vs-local.mdx**: Updated comparison table with plugin names and package sizes. Switching instructions now install the correct plugin instead of changing a mode setting.
- **contributing.mdx**: Added `packages/openclaw-plugins/` to project structure. Added plugin test commands.
- **introduction.mdx**: Updated privacy section to reference plugin names instead of modes.