### PR TITLE
Update docs for routing-only architecture

### DIFF
--- a/cloud-vs-local.mdx
+++ b/cloud-vs-local.mdx
@@ -1,25 +1,23 @@
 ---
 title: "Cloud vs Local"
-description: "Choose the right plugin for your workflow"
+description: "Choose the right mode for your workflow"
 icon: "cloud"
 ---
 
-Manifest ships as two plugins: **manifest-provider** (cloud, hosted at app.manifest.build) and **manifest** (self-hosted, runs on your machine). Same routing and dashboard, different tradeoffs on privacy and convenience.
+Manifest is available in two modes: **Cloud** (hosted at app.manifest.build, configured as a custom provider in OpenClaw) and **Local** (self-hosted plugin that runs on your machine). Same routing and dashboard, different tradeoffs on privacy and convenience.
 
 ## Comparison
 
-| | Cloud (`manifest-provider`) | Local (`manifest`) |
+| | Cloud | Local |
 |---|---|---|
-| **Setup** | Sign up + API key | Zero config |
-| **Package size** | ~22 KB | ~50 MB |
+| **Setup** | Sign up + provider config | Plugin install, zero config |
 | **Data storage** | PostgreSQL (hosted) | SQLite on your machine |
 | **Dashboard** | app.manifest.build | http://127.0.0.1:2099 |
 | **Auth** | Email/password or OAuth (Google, GitHub, Discord) | Auto-login (loopback trust) |
 | **Multi-device** | Yes — access from any browser | No — localhost only |
 | **API key** | Generated in dashboard (`mnfst_...`) | Auto-generated (`mnfst_local_...`) |
 | **Email alerts** | Built-in (platform mail) | Requires provider config (Mailgun/Resend/SendGrid) |
-| **Telemetry interval** | ~30 seconds | ~10 seconds |
-| **Privacy** | Metadata only (no message content) | 100% on your machine |
+| **Privacy** | Requests routed through Manifest proxy; content not persisted | 100% on your machine |
 | **Cost** | Free | Free |
 
 ## When to use Cloud
@@ -33,18 +31,6 @@ Manifest ships as two plugins: **manifest-provider** (cloud, hosted at app.manif
 - You don't want any data leaving your machine.
 - You don't need multi-device access.
 - You want something that works offline with no setup.
+- You want to use local models like Ollama.
 
-## Switching plugins
-
-```bash
-# Switch to cloud
-openclaw plugins install manifest-provider
-openclaw providers setup manifest-provider
-openclaw gateway restart
-
-# Switch to local
-openclaw plugins install manifest
-openclaw gateway restart
-```
-
-<Warning>Switching does not migrate data. Cloud and local have separate databases.</Warning>
+<Info>Cloud and Local are independent. They have separate data stores and are not interchangeable.</Info>

--- a/configuration.mdx
+++ b/configuration.mdx
@@ -13,16 +13,33 @@ Set via `openclaw config set plugins.entries.manifest.config.<key> <value>`.
 | `port` | `number` | `2099` | Embedded server port |
 | `host` | `string` | `127.0.0.1` | Bind address |
 
-## manifest-provider (cloud)
+## Cloud (provider config)
 
-Set via `openclaw config set plugins.entries.manifest-provider.config.<key> <value>`.
+Cloud mode is configured as a custom provider in `~/.openclaw/openclaw.json` under `models.providers.manifest`.
 
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `devMode` | `boolean` | auto | Skip API key validation. Auto-detected when the endpoint is a loopback address. |
-| `endpoint` | `string` | `https://app.manifest.build` | Manifest server URL |
+Set via `openclaw config set models.providers.manifest '<json>'`.
 
-API key is set via `openclaw providers setup manifest-provider` (interactive) or the `MANIFEST_API_KEY` environment variable.
+```json
+{
+  "baseUrl": "https://app.manifest.build/v1",
+  "api": "openai-completions",
+  "apiKey": "mnfst_YOUR_KEY",
+  "models": [{ "id": "auto", "name": "Manifest Auto" }]
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `baseUrl` | `string` | Yes | Manifest API endpoint (`https://app.manifest.build/v1`) |
+| `api` | `string` | Yes | Must be `openai-completions` |
+| `apiKey` | `string` | Yes | Your Manifest API key (`mnfst_...`) |
+| `models` | `array` | Yes | Model list. Use `[{"id":"auto","name":"Manifest Auto"}]` |
+
+The default model is set separately:
+
+```bash
+openclaw config set agents.defaults.model.primary manifest/auto
+```
 
 ## Environment variables
 
@@ -63,7 +80,11 @@ API key is set via `openclaw providers setup manifest-provider` (interactive) or
 
 <Tabs>
   <Tab title="Cloud">
-    All config is managed via environment variables or the dashboard UI. No local config files.
+    | Path | Description |
+    |------|-------------|
+    | `~/.openclaw/openclaw.json` | Provider config under `models.providers.manifest` |
+
+    All other config is managed via the dashboard UI. For self-hosting, use environment variables.
   </Tab>
   <Tab title="Local">
     | Path | Description |

--- a/contributing.mdx
+++ b/contributing.mdx
@@ -22,7 +22,7 @@ packages/
 ├── frontend/             # SolidJS dashboard
 └── openclaw-plugins/
     ├── manifest/          # npm: manifest — self-hosted plugin (embedded server + dashboard)
-    └── manifest-provider/ # npm: manifest-provider — cloud-only provider plugin
+    └── manifest-provider/ # npm: manifest-provider — cloud provider bridge
 ```
 
 ## Prerequisites

--- a/install.mdx
+++ b/install.mdx
@@ -32,20 +32,16 @@ icon: "download"
       <Step title="Copy your API key">
         Copy the generated API key (`mnfst_...`).
       </Step>
-      <Step title="Install the plugin">
+      <Step title="Add Manifest as a provider">
         ```bash
-        openclaw plugins install manifest-provider
+        openclaw config set models.providers.manifest \
+          '{"baseUrl":"https://app.manifest.build/v1","api":"openai-completions","apiKey":"mnfst_YOUR_KEY","models":[{"id":"auto","name":"Manifest Auto"}]}'
         ```
+        Replace `mnfst_YOUR_KEY` with the key from the previous step.
       </Step>
-      <Step title="Set up your API key">
+      <Step title="Set the default model">
         ```bash
-        openclaw providers setup manifest-provider
-        ```
-        This prompts you for the API key interactively.
-
-        In CI/CD, set the key as an environment variable instead:
-        ```bash
-        export MANIFEST_API_KEY=mnfst_YOUR_KEY
+        openclaw config set agents.defaults.model.primary manifest/auto
         ```
       </Step>
       <Step title="Restart the gateway">
@@ -54,6 +50,8 @@ icon: "download"
         ```
       </Step>
     </Steps>
+
+    <Tip>You can also run `openclaw onboard`, select **Custom Provider**, and enter the Base URL (`https://app.manifest.build/v1`), your API key, model ID (`auto`), and endpoint ID (`manifest`).</Tip>
   </Tab>
   <Tab title="Local">
     <Steps>
@@ -90,4 +88,4 @@ icon: "download"
   </Tab>
 </Tabs>
 
-<Info>The gateway batches telemetry every 10-30 seconds. New messages may take a moment to appear.</Info>
+<Info>Usage data appears in the dashboard as requests flow through the router.</Info>

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -4,7 +4,7 @@ description: "Take control of your OpenClaw costs."
 icon: "house"
 ---
 
-Manifest is an open-source OpenClaw plugin that routes queries to the cheapest model that can handle them. It comes with a dashboard for tracking tokens, costs, and usage.
+Manifest is an open-source LLM router for OpenClaw that routes queries to the cheapest model that can handle them. It comes with a dashboard for tracking tokens, costs, and usage.
 
 ## Why Manifest
 
@@ -22,7 +22,7 @@ Manifest is an open-source OpenClaw plugin that routes queries to the cheapest m
 
 ## How it works
 
-Manifest intercepts each OpenClaw request, scores the query in under 2 ms, assigns a tier (simple / standard / complex / reasoning), and forwards it to the matching model. Token counts, latency, and cost data are collected via OpenTelemetry and show up in the dashboard.
+Manifest intercepts each OpenClaw request, scores the query in under 2 ms, assigns a tier (simple / standard / complex / reasoning), and forwards it to the matching model. Token counts, latency, and cost data are captured as requests flow through the router and show up in the dashboard.
 
 ## Manifest vs OpenRouter
 
@@ -34,12 +34,12 @@ Manifest intercepts each OpenClaw request, scores the query in under 2 ms, assig
 | **Routing logic** | Transparent, open-source scoring | Black box |
 | **Cost** | Free | Per-token markup |
 | **Dashboard** | Built-in | Separate |
-| **Works with OpenClaw** | Native plugin | Requires config |
+| **Works with OpenClaw** | Native integration | Requires config |
 
 ## Privacy
 
-- **Local plugin (`manifest`):** All data stays on your machine. Nothing is sent anywhere.
-- **Cloud plugin (`manifest-provider`):** Only OpenTelemetry metadata (model name, token counts, latency) is sent. Message content never leaves your machine.
+- **Local:** All data stays on your machine. Nothing is sent anywhere.
+- **Cloud:** Requests are routed through the Manifest proxy. Only model name, token counts, and latency are stored. Message content is not persisted.
 
 ## Next step
 

--- a/set-limits.mdx
+++ b/set-limits.mdx
@@ -8,46 +8,31 @@ icon: "shield-alert"
 
 Two types of rules you can set per agent:
 
-- **Notify** — Sends you an email when a threshold is hit.
-- **Block** — Returns HTTP 429 and stops requests once the threshold is hit.
+- **Email Alert** — Sends you an email when a threshold is hit.
+- **Hard Limit** — Returns HTTP 429 and stops requests once the threshold is hit.
+
+You can also combine both on a single rule.
 
 ## Creating a rule
 
-<Tabs>
-  <Tab title="Cloud">
-    <Steps>
-      <Step title="Open agent settings">
-        Open your agent's Settings page in the dashboard.
-      </Step>
-      <Step title="Add a rule">
-        Under "Notification Rules", click **Add Rule**.
-      </Step>
-      <Step title="Configure the rule">
-        Pick a metric (tokens or cost), period (hour / day / week / month), threshold, and action (notify or block).
-      </Step>
-      <Step title="Save">
-        Save. The rule takes effect immediately.
-      </Step>
-    </Steps>
-  </Tab>
-  <Tab title="Local">
-    <Steps>
-      <Step title="Open the dashboard">
-        Open [http://127.0.0.1:2099](http://127.0.0.1:2099) and navigate to your agent's settings.
-      </Step>
-      <Step title="Add a rule">
-        Add a rule with metric, period, threshold, and action.
-      </Step>
-      <Step title="Save">
-        Save. The rule takes effect immediately.
-      </Step>
-    </Steps>
-  </Tab>
-</Tabs>
+<Steps>
+  <Step title="Open the Limits page">
+    Navigate to your agent's **Limits** page in the dashboard.
+  </Step>
+  <Step title="Create a rule">
+    Click **+ Create rule**.
+  </Step>
+  <Step title="Configure the rule">
+    Pick a rule type (Email Alert, Hard Limit, or both), a metric (tokens or cost), a threshold, and a period (hour / day / week / month).
+  </Step>
+  <Step title="Save">
+    Click **Create rule**. The rule takes effect immediately.
+  </Step>
+</Steps>
 
 ## How blocking works
 
-When a "block" rule triggers, the next ingest request returns `429 Too Many Requests` with a message:
+When a Hard Limit triggers, the next proxy request returns `429 Too Many Requests` with a message:
 
 ```
 Limit exceeded: cost usage ($X) exceeds $Y per day
@@ -59,27 +44,20 @@ The block resets at the start of the next period.
 
 <Tabs>
   <Tab title="Cloud">
-    Emails are sent through the platform's mail provider. Make sure your account email is correct.
+    Alerts are sent to your account email. Make sure it is correct in your profile settings.
   </Tab>
   <Tab title="Local">
-    Configure an email provider in `~/.openclaw/manifest/config.json`:
+    Choose an email provider in the dashboard's **Limits** page. Supported providers:
 
-    ```json
-    {
-      "email": {
-        "provider": "mailgun",
-        "apiKey": "key-...",
-        "domain": "mg.example.com",
-        "from": "alerts@example.com"
-      }
-    }
-    ```
+    - **Resend**
+    - **Mailgun**
+    - **SendGrid**
 
-    Supported providers: Mailgun, Resend, SendGrid. If no provider is configured, email notifications are skipped (block rules still work).
+    Click a provider card, enter your API key, domain, and notification email, then save. If no provider is configured, email alerts are skipped (Hard Limit rules still work).
   </Tab>
 </Tabs>
 
 ## Checking rules
 
-- Rules are evaluated hourly (cron) for notifications, and on every ingest for blocks.
+- Rules are evaluated hourly (cron) for notifications, and on every request for blocks.
 - A notification is sent once per rule per period to avoid spam.

--- a/track-usage.mdx
+++ b/track-usage.mdx
@@ -6,6 +6,8 @@ icon: "chart-bar"
 
 ## Dashboard
 
+Usage data is captured automatically as requests flow through the Manifest routing proxy. Every LLM call routed through `manifest/auto` is recorded.
+
 The main dashboard shows:
 
 - **Total messages** — number of LLM calls.


### PR DESCRIPTION
## Summary

- **Cloud setup rewritten**: Plugin install (`manifest-provider`) replaced with custom provider config (`models.providers.manifest`). Added `openclaw onboard` as alternative method.
- **OTLP/telemetry references removed**: All OpenTelemetry mentions replaced with routing proxy language across introduction, install, track-usage, and configuration pages.
- **Cloud vs Local rewritten**: No longer describes two plugins — cloud is a provider config, local is a plugin. Removed "Switching plugins" section. Added Ollama use case to local.
- **Set limits unified**: Rule creation is now a single flow (no cloud/local tabs). Updated terminology to match UI (Email Alert / Hard Limit). Local email setup now describes the dashboard provider picker (Resend/Mailgun/SendGrid) instead of manual JSON config.
- **Configuration updated**: Cloud section shows `models.providers.manifest` JSON structure with field reference table instead of plugin config.

## Test plan

- [ ] All pages render correctly in Mintlify dev server
- [ ] No remaining references to OTLP, OpenTelemetry, or `plugins install manifest-provider`
- [ ] Cloud install steps match the current setup wizard flow
- [ ] Set limits page matches the current Limits UI