### PR TITLE
Simplify cloud setup, rename Install to Getting Started

### DIFF
--- a/install.mdx
+++ b/install.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Install"
-description: "Install Manifest and start routing"
-icon: "download"
+title: "Getting Started"
+description: "Set up Manifest and start routing"
+icon: "rocket"
 ---
 
 ## Prerequisites
@@ -18,7 +18,7 @@ icon: "download"
   </Tab>
 </Tabs>
 
-## Install
+## Setup
 
 <Tabs>
   <Tab title="Cloud">
@@ -29,29 +29,10 @@ icon: "download"
       <Step title="Create an agent">
         Open the Workspace page and create a new agent.
       </Step>
-      <Step title="Copy your API key">
-        Copy the generated API key (`mnfst_...`).
-      </Step>
-      <Step title="Add Manifest as a provider">
-        ```bash
-        openclaw config set models.providers.manifest \
-          '{"baseUrl":"https://app.manifest.build/v1","api":"openai-completions","apiKey":"mnfst_YOUR_KEY","models":[{"id":"auto","name":"Manifest Auto"}]}'
-        ```
-        Replace `mnfst_YOUR_KEY` with the key from the previous step.
-      </Step>
-      <Step title="Set the default model">
-        ```bash
-        openclaw config set agents.defaults.model.primary manifest/auto
-        ```
-      </Step>
-      <Step title="Restart the gateway">
-        ```bash
-        openclaw gateway restart
-        ```
+      <Step title="Follow the install wizard">
+        The dashboard shows setup instructions with everything pre-filled. Follow the steps to add Manifest as a provider in OpenClaw and restart the gateway.
       </Step>
     </Steps>
-
-    <Tip>You can also run `openclaw onboard`, select **Custom Provider**, and enter the Base URL (`https://app.manifest.build/v1`), your API key, model ID (`auto`), and endpoint ID (`manifest`).</Tip>
   </Tab>
   <Tab title="Local">
     <Steps>
@@ -88,4 +69,4 @@ icon: "download"
   </Tab>
 </Tabs>
 
-<Info>Usage data appears in the dashboard as requests flow through the router.</Info>
+<Info>Usage data is recorded each time a request is routed through `manifest/auto`.</Info>

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -43,6 +43,6 @@ Manifest intercepts each OpenClaw request, scores the query in under 2 ms, assig
 
 ## Next step
 
-<Card title="Install Manifest" icon="arrow-down-to-line" href="/install">
-  Install Manifest and start routing.
+<Card title="Get started" icon="rocket" href="/install">
+  Set up Manifest and start routing.
 </Card>

--- a/track-usage.mdx
+++ b/track-usage.mdx
@@ -6,7 +6,7 @@ icon: "chart-bar"
 
 ## Dashboard
 
-Usage data is captured automatically as requests flow through the Manifest routing proxy. Every LLM call routed through `manifest/auto` is recorded.
+Usage data is recorded each time a request is routed through `manifest/auto`.
 
 The main dashboard shows:
 


### PR DESCRIPTION
## Summary

- Cloud setup now directs users to the dashboard install wizard (3 steps: sign up, create agent, follow wizard) instead of manual CLI commands
- Renamed "Install" page to "Getting Started"
- Updated usage data wording to be clearer

## Test plan

- [ ] Getting Started page renders correctly with simplified cloud steps
- [ ] Introduction CTA card links to Getting Started correctly
- [ ] Track usage page wording is accurate