### PR TITLE
Add redirect from /docs to /introduction

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -137,6 +137,10 @@
     {
       "source": "/",
       "destination": "/introduction"
+    },
+    {
+      "source": "/docs",
+      "destination": "/introduction"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Added a new redirect rule to route requests from `/docs` to the `/introduction` page.

## Changes
- Added a new redirect configuration in `docs.json` that maps the `/docs` path to `/introduction`
- This complements the existing redirect from `/` to `/introduction`

## Details
The redirect rule follows the same pattern as the existing root path redirect, ensuring consistent routing behavior for users accessing the `/docs` endpoint.

https://claude.ai/code/session_016dVRfrNroLZdKsor3j8mq7