### PR TITLE
fix: broken install link, scoring categories, model count

### DIFF
--- a/introduction.mdx
+++ b/introduction.mdx
@@ -43,6 +43,6 @@ Manifest intercepts each OpenClaw request, scores the query in under 2 ms, assig
 
 ## Next step
 
-<Card title="Get started" icon="rocket" href="/install">
+<Card title="Get started" icon="rocket" href="/docs/get-started">
   Set up Manifest and start routing.
 </Card>

--- a/routing.mdx
+++ b/routing.mdx
@@ -30,11 +30,13 @@ Instead of sending every request to the same expensive model, Manifest scores ea
 
 ## How scoring works
 
-23 dimensions grouped into two categories:
+23 dimensions grouped into three categories:
 
 **Keyword-based (14)** — Scans the prompt for patterns like "prove", "write function", "what is", etc.
 
-**Structural (9)** — Analyzes token count, nesting depth, code-to-prose ratio, tool count, conversation depth, etc.
+**Structural (5)** — Analyzes token count, nesting depth, code-to-prose ratio, conditional logic, and constraint density.
+
+**Contextual (4)** — Considers expected output length, repetition requests, tool count, and conversation depth.
 
 Each dimension has a weight. The weighted sum maps to a tier via threshold boundaries. A confidence score (0–1) indicates how clearly the request fits its tier.
 

--- a/track-usage.mdx
+++ b/track-usage.mdx
@@ -35,7 +35,7 @@ The main dashboard shows:
 
 ## How cost is calculated
 
-Manifest has pricing data for 40+ models across Anthropic, OpenAI, Google, DeepSeek, and others.
+Manifest has pricing data for 300+ models across Anthropic, OpenAI, Google, DeepSeek, and others.
 
 ```
 Cost = input_tokens × input_price + output_tokens × output_price


### PR DESCRIPTION
## Summary

Fixes 3 dissonances found in a docs consistency audit against the codebase:

- **introduction.mdx**: "Get started" card links to `/install` which returns 404. Changed to `/docs/get-started`.
- **routing.mdx**: Scoring dimensions described as 2 categories (keyword 14, structural 9) but the codebase has 3 categories: keyword (14), structural (5), contextual (4). Fixed.
- **track-usage.mdx**: "pricing data for 40+ models" is stale — OpenRouter sync provides 300+ models. Updated.

## Test plan

- [ ] Verify `/docs/get-started` link works
- [ ] Verify dimension counts match `packages/backend/src/routing/scorer/`