### PR TITLE
feat: add Docker installation guide

### DIFF
--- a/cloud-vs-local.mdx
+++ b/cloud-vs-local.mdx
@@ -1,24 +1,25 @@
 ---
-title: "Cloud vs Local"
+title: "Cloud vs Local vs Docker"
 description: "Choose the right mode for your workflow"
 icon: "cloud"
 ---
 
-Manifest is available in two modes: **Cloud** (hosted at app.manifest.build, configured as a custom provider in OpenClaw) and **Local** (self-hosted plugin that runs on your machine). Same routing and dashboard, different tradeoffs on privacy and convenience.
+Manifest is available in three modes: **Cloud** (hosted at app.manifest.build), **Local** (self-hosted plugin on your machine), and **Docker** (self-hosted with Docker). Same routing and dashboard, different tradeoffs.
 
 ## Comparison
 
-| | Cloud | Local |
-|---|---|---|
-| **Setup** | Sign up + provider config | Plugin install, zero config |
-| **Data storage** | PostgreSQL (hosted) | SQLite on your machine |
-| **Dashboard** | app.manifest.build | http://127.0.0.1:2099 |
-| **Auth** | Email/password or OAuth (Google, GitHub, Discord) | Auto-login (loopback trust) |
-| **Multi-device** | Yes — access from any browser | No — localhost only |
-| **API key** | Generated in dashboard (`mnfst_...`) | Auto-generated (`mnfst_local_...`) |
-| **Email alerts** | Built-in (platform mail) | Requires provider config (Mailgun/Resend/SendGrid) |
-| **Privacy** | Requests routed through Manifest proxy; content not persisted | 100% on your machine |
-| **Cost** | Free | Free |
+| | Cloud | Local | Docker |
+|---|---|---|---|
+| **Setup** | Sign up + provider config | Plugin install, zero config | `docker compose up` |
+| **Data storage** | PostgreSQL (hosted) | SQLite on your machine | PostgreSQL (self-hosted) |
+| **Dashboard** | app.manifest.build | http://127.0.0.1:2099 | http://localhost:3001 |
+| **Auth** | Email/password or OAuth | Auto-login (loopback trust) | Email/password |
+| **Multi-device** | Yes — access from any browser | No — localhost only | Yes — within your network |
+| **API key** | Generated in dashboard (`mnfst_...`) | Auto-generated (`mnfst_local_...`) | Generated in dashboard (`mnfst_...`) |
+| **Email alerts** | Built-in (platform mail) | Requires provider config | Requires provider config |
+| **Privacy** | Requests routed through Manifest proxy | 100% on your machine | 100% on your machine |
+| **Requirements** | OpenClaw + account | OpenClaw + Node.js >= 20 | Docker only |
+| **Cost** | Free | Free | Free |
 
 ## When to use Cloud
 
@@ -33,4 +34,11 @@ Manifest is available in two modes: **Cloud** (hosted at app.manifest.build, con
 - You want something that works offline with no setup.
 - You want to use local models like Ollama.
 
-<Info>Cloud and Local are independent. They have separate data stores and are not interchangeable.</Info>
+## When to use Docker
+
+- You want full control over your data with a PostgreSQL database.
+- You don't have Node.js installed.
+- You want to deploy Manifest on a server or in a container orchestrator.
+- You want the full dashboard experience (login, multi-user) without the hosted cloud.
+
+<Info>All three modes are independent. They have separate data stores and are not interchangeable.</Info>

--- a/docker.mdx
+++ b/docker.mdx
@@ -1,0 +1,106 @@
+---
+title: "Docker"
+description: "Run Manifest with Docker"
+icon: "docker"
+---
+
+Run the full Manifest stack with Docker. No Node.js required — just Docker.
+
+## Quick start
+
+<Steps>
+  <Step title="Download the compose file">
+    ```bash
+    curl -O https://raw.githubusercontent.com/mnfst/manifest/main/docker-compose.yml
+    ```
+  </Step>
+  <Step title="Start the services">
+    ```bash
+    docker compose up -d
+    ```
+
+    This starts Manifest and a PostgreSQL database.
+  </Step>
+  <Step title="Open the dashboard">
+    Go to [http://localhost:3001](http://localhost:3001) and log in with the demo account:
+
+    - **Email:** `admin@manifest.build`
+    - **Password:** `manifest`
+  </Step>
+  <Step title="Connect a provider">
+    Open the **Routing** page and add an LLM provider (OpenAI, Anthropic, Gemini, etc.) with your API key.
+  </Step>
+  <Step title="Connect OpenClaw">
+    In the agent settings, copy the setup command and run it in your terminal:
+
+    ```bash
+    openclaw config set plugins.entries.manifest-model-router.config.devMode true
+    openclaw config set plugins.entries.manifest-model-router.config.endpoint http://localhost:3001
+    openclaw gateway restart
+    ```
+  </Step>
+</Steps>
+
+## Verify
+
+Send a message through OpenClaw. It should appear in the Manifest dashboard within a few seconds.
+
+```bash
+curl -X POST http://localhost:3001/v1/chat/completions \
+  -H "Authorization: Bearer YOUR_MNFST_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "manifest/auto", "messages": [{"role": "user", "content": "Hello"}]}'
+```
+
+## Custom port
+
+To run on a different port (e.g. 8080), update both the port mapping and `BETTER_AUTH_URL` in `docker-compose.yml`:
+
+```yaml
+ports:
+  - "8080:3001"
+environment:
+  - BETTER_AUTH_URL=http://localhost:8080
+```
+
+<Warning>If you see an "Invalid origin" error on the login page, `BETTER_AUTH_URL` doesn't match the port you're accessing the dashboard on.</Warning>
+
+## Standalone (bring your own PostgreSQL)
+
+If you already have a PostgreSQL instance:
+
+```bash
+docker run -d \
+  -p 3001:3001 \
+  -e DATABASE_URL=postgresql://user:pass@host:5432/manifest \
+  -e BETTER_AUTH_SECRET=$(openssl rand -hex 32) \
+  -e BETTER_AUTH_URL=http://localhost:3001 \
+  -e NODE_ENV=development \
+  -e MANIFEST_TRUST_LAN=true \
+  manifestdotbuild/manifest
+```
+
+<Info>`NODE_ENV=development` enables automatic database migrations on startup.</Info>
+
+## Environment variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `DATABASE_URL` | Yes | — | PostgreSQL connection string |
+| `BETTER_AUTH_SECRET` | Yes | — | Session signing secret (min 32 chars). Generate with `openssl rand -hex 32` |
+| `BETTER_AUTH_URL` | No | `http://localhost:3001` | Public URL of the app. Set when using a custom port |
+| `PORT` | No | `3001` | Internal server port |
+| `NODE_ENV` | No | `production` | Set `development` for auto-migrations |
+| `SEED_DATA` | No | `false` | Seed demo data on startup |
+| `MANIFEST_TRUST_LAN` | No | `false` | Trust private network IPs for auth (required for Docker) |
+
+## Stop and clean up
+
+```bash
+docker compose down       # Stop services (keeps data)
+docker compose down -v    # Stop and delete all data
+```
+
+## Docker Hub
+
+The image is available at [manifestdotbuild/manifest](https://hub.docker.com/r/manifestdotbuild/manifest) on Docker Hub.

--- a/docs.json
+++ b/docs.json
@@ -72,6 +72,7 @@
             "pages": [
               "introduction",
               "get-started",
+              "docker",
               "cloud-vs-local"
             ]
           },

--- a/get-started.mdx
+++ b/get-started.mdx
@@ -16,6 +16,10 @@ icon: "rocket"
     - Node.js >= 20.
     - No account needed.
   </Tab>
+  <Tab title="Docker">
+    - Docker installed on your machine.
+    - No Node.js or account needed.
+  </Tab>
 </Tabs>
 
 ## Setup
@@ -56,6 +60,25 @@ icon: "rocket"
     openclaw config set plugins.entries.manifest.config.port 3000
     ```
   </Tab>
+  <Tab title="Docker">
+    <Steps>
+      <Step title="Download the compose file">
+        ```bash
+        curl -O https://raw.githubusercontent.com/mnfst/manifest/main/docker-compose.yml
+        ```
+      </Step>
+      <Step title="Start the services">
+        ```bash
+        docker compose up -d
+        ```
+      </Step>
+      <Step title="Open the dashboard">
+        Go to [http://localhost:3001](http://localhost:3001) and log in with `admin@manifest.build` / `manifest`.
+      </Step>
+    </Steps>
+
+    See the full [Docker guide](/docker) for custom ports, standalone mode, and environment variables.
+  </Tab>
 </Tabs>
 
 ## Verify
@@ -66,6 +89,9 @@ icon: "rocket"
   </Tab>
   <Tab title="Local">
     Open [http://127.0.0.1:2099](http://127.0.0.1:2099). Send a message to any agent. It should appear in the dashboard within 10 seconds.
+  </Tab>
+  <Tab title="Docker">
+    Open [http://localhost:3001](http://localhost:3001). Connect a provider on the Routing page, then send a message. It should appear in the dashboard immediately.
   </Tab>
 </Tabs>
 


### PR DESCRIPTION
## Summary

- Add `docker.mdx` — complete Docker installation guide covering compose quick-start, standalone mode, custom ports, environment variables, and cleanup
- Add Docker tab to `get-started.mdx` (prerequisites, setup, verify sections)
- Update `cloud-vs-local.mdx` to "Cloud vs Local vs Docker" with a three-way comparison table
- Add Docker page to navigation in `docs.json`

Companion to mnfst/manifest#1410 which adds the Dockerfile, docker-compose.yml, and CI workflow.

## Test plan

- [ ] `docker.mdx` renders correctly in Mintlify
- [ ] Docker tab appears in get-started.mdx
- [ ] Cloud vs Local vs Docker comparison table is readable
- [ ] Navigation link works in sidebar