### PR TITLE
Add upgrade warning callout for pre-v5.36.1 users

### DIFF
--- a/get-started.mdx
+++ b/get-started.mdx
@@ -20,6 +20,15 @@ icon: "rocket"
 
 ## Setup
 
+<Warning>
+  **Upgrading from before `v5.36.1`?** Run these commands first to clean up your workspace.
+  ```bash
+  openclaw plugins uninstall manifest-provider
+  openclaw plugins uninstall manifest
+  openclaw gateway restart
+  ```
+</Warning>
+
 <Tabs>
   <Tab title="Cloud">
     <Steps>

--- a/style.css
+++ b/style.css
@@ -24,3 +24,25 @@
 #footer a[href*="mintlify"] {
   display: none;
 }
+
+/* Callouts: tighter spacing & smaller radii */
+.callout {
+  border-radius: 6px !important;
+  padding: 10px 14px !important;
+  margin-top: 12px !important;
+  margin-bottom: 12px !important;
+}
+
+.callout pre {
+  border-radius: 4px !important;
+  margin-top: 8px !important;
+  margin-bottom: 8px !important;
+}
+
+.callout p:last-child {
+  margin-top: 0 !important;
+}
+
+.callout .code-block {
+  margin-bottom: 0.5rem !important;
+}


### PR DESCRIPTION
## Summary
- Add a warning callout in the Setup section of get-started page for users upgrading from before v5.36.1
- Include workspace cleanup commands (uninstall old plugins + gateway restart)
- Add custom CSS for callouts: smaller border-radius, tighter spacing

## Test plan
- [ ] Verify the warning callout renders correctly on the get-started page
- [ ] Check styling (border-radius, margins, padding) looks consistent
- [ ] Confirm code block inside callout has proper spacing