### PR TITLE
Clarify self-hosted install guide (e2e findings)

### DIFF
--- a/get-started.mdx
+++ b/get-started.mdx
@@ -42,13 +42,15 @@ icon: "rocket"
         ```bash
         docker compose up -d
         ```
+
+        Give it about 30 seconds to boot.
       </Step>
       <Step title="Open the dashboard">
         Go to [http://localhost:3001](http://localhost:3001) and log in with `admin@manifest.build` / `manifest`.
       </Step>
     </Steps>
 
-    See the full [Self-hosted guide](/self-hosted) for custom ports, standalone mode, and environment variables.
+    See the full [Self-hosted guide](/self-hosted) for provider setup, custom ports, and environment variables.
   </Tab>
 </Tabs>
 
@@ -59,7 +61,7 @@ icon: "rocket"
     Open [app.manifest.build](https://app.manifest.build). Send a message to any agent. It should appear in the dashboard within 30 seconds.
   </Tab>
   <Tab title="Self-hosted">
-    Open [http://localhost:3001](http://localhost:3001). Connect a provider on the Routing page, then send a message. It should appear in the dashboard immediately.
+    Open [http://localhost:3001](http://localhost:3001), connect a provider on the [Routing](http://localhost:3001/routing) page, then send a test request. It should appear on the Messages page within seconds. See the [Self-hosted guide](/self-hosted#verify) for the exact verify command.
   </Tab>
 </Tabs>
 

--- a/self-hosted.mdx
+++ b/self-hosted.mdx
@@ -6,10 +6,6 @@ icon: "docker"
 
 Run the full Manifest stack on your own machine. No Node.js required, just Docker.
 
-<Warning>
-  **The OpenClaw plugin install is deprecated.** If you previously ran `openclaw plugins install manifest` (the [`manifest`](https://www.npmjs.com/package/manifest) npm package), it still works but is no longer recommended. New installs should use the Docker path below.
-</Warning>
-
 ## Quick start
 
 <Steps>
@@ -23,7 +19,7 @@ Run the full Manifest stack on your own machine. No Node.js required, just Docke
     docker compose up -d
     ```
 
-    This starts Manifest and a PostgreSQL database.
+    This starts Manifest and a PostgreSQL database. Give it about 30 seconds to boot on a cold pull — you can watch startup with `docker compose logs -f manifest`.
   </Step>
   <Step title="Open the dashboard">
     Go to [http://localhost:3001](http://localhost:3001) and log in with the demo account:
@@ -32,29 +28,40 @@ Run the full Manifest stack on your own machine. No Node.js required, just Docke
     - **Password:** `manifest`
   </Step>
   <Step title="Connect a provider">
-    Open the **Routing** page and add an LLM provider (OpenAI, Anthropic, Gemini, etc.) with your API key.
+    Open the [Routing](http://localhost:3001/routing) page and add an LLM provider (OpenAI, Anthropic, Gemini, etc.) with your API key.
   </Step>
-  <Step title="Connect OpenClaw">
-    In the agent settings, copy the setup command and run it in your terminal:
+  <Step title="(Optional) Connect OpenClaw">
+    If you use OpenClaw, point it at this Manifest instance from your terminal:
 
     ```bash
     openclaw config set plugins.entries.manifest-model-router.config.devMode true
     openclaw config set plugins.entries.manifest-model-router.config.endpoint http://localhost:3001
     openclaw gateway restart
     ```
+
+    Requires the `openclaw` CLI. Skip this step if you don't use OpenClaw — the dashboard works without it.
   </Step>
 </Steps>
 
+<Warning>
+  **The default compose file is for local testing only.** It ships with `SEED_DATA=true` (populates a fake `demo-agent` with sample token usage), a placeholder `BETTER_AUTH_SECRET`, and the well-known `admin@manifest.build` / `manifest` credentials. Before exposing this instance beyond localhost, set `SEED_DATA=false`, replace the secret with `openssl rand -hex 32`, and change the admin password.
+</Warning>
+
 ## Verify
 
-Send a message through OpenClaw. It should appear in the Manifest dashboard within a few seconds.
+After connecting a provider, send a test request and watch it land in the dashboard.
 
-```bash
-curl -X POST http://localhost:3001/v1/chat/completions \
-  -H "Authorization: Bearer YOUR_MNFST_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"model": "manifest/auto", "messages": [{"role": "user", "content": "Hello"}]}'
-```
+- **From OpenClaw** (if you completed the optional step above): trigger any agent request. It should appear on the **Messages** page within a few seconds.
+- **From the API directly:** grab your Manifest API key from the dashboard (it starts with `mnfst_`) and run:
+
+  ```bash
+  curl -X POST http://localhost:3001/v1/chat/completions \
+    -H "Authorization: Bearer mnfst_YOUR_KEY_HERE" \
+    -H "Content-Type: application/json" \
+    -d '{"model": "manifest/auto", "messages": [{"role": "user", "content": "Hello"}]}'
+  ```
+
+  If the response comes back with `[🦚 Manifest] That doesn't look like a Manifest key`, you're still using the placeholder — replace `mnfst_YOUR_KEY_HERE` with the real key from the dashboard.
 
 ## Custom port
 
@@ -141,3 +148,13 @@ docker compose down -v    # Stop and delete all data
 ## Docker Hub
 
 The image is available at [manifestdotbuild/manifest](https://hub.docker.com/r/manifestdotbuild/manifest) on Docker Hub.
+
+## Migrating from the OpenClaw plugin
+
+If you previously ran `openclaw plugins install manifest` (the [`manifest`](https://www.npmjs.com/package/manifest) npm package), it still works but is no longer recommended. Switch to the Docker path above, then uninstall the plugin:
+
+```bash
+openclaw plugins uninstall manifest
+openclaw plugins uninstall manifest-provider
+openclaw gateway restart
+```


### PR DESCRIPTION
## Summary

Applied after walking through the self-hosted install guide end-to-end on a clean machine. Every executable step in the docs worked, but a few spots were likely to confuse a first-time reader.

## Changes

- **Verify section rewritten.** The old curl used `YOUR_MNFST_KEY` as a literal placeholder with no explanation of where to find the real key. When the placeholder is sent, the server returns a friendly HTTP 200 with a pseudo-response (\`[🦚 Manifest] That doesn't look like a Manifest key\`), which a reader could easily mistake for a successful verify. New section offers two clear paths — an OpenClaw agent request (if they connected it) or an API curl with an \`mnfst_\` key fetched from the dashboard — and points out the placeholder-detector message as a troubleshooting hint.

- **Connect OpenClaw is now \`(Optional)\`.** With a note that it requires the \`openclaw\` CLI. Readers who don't have OpenClaw installed were otherwise stuck on the last step, despite the dashboard being fully functional without it. Prerequisites stay minimal (just Docker).

- **New Warning callout after Quick Start** covering the three demo defaults that aren't safe beyond localhost: \`SEED_DATA=true\` (populates a fake \`demo-agent\` with sample token usage), placeholder \`BETTER_AUTH_SECRET=change-me-to-a-random-32-char-string!!\`, and the well-known \`admin@manifest.build\` / \`manifest\` credentials. Tells the reader exactly what to change before exposing the instance.

- **Boot-time hint.** The "Start the services" step now says "Give it about 30 seconds to boot on a cold pull — you can watch startup with \`docker compose logs -f manifest\`." On my test the container took ~25s from created to accepting requests, which is long enough that a reader clicking through immediately gets a connection refused.

- **OpenClaw plugin deprecation Warning moved.** Previously it sat right under the intro and was the first thing a new reader saw, despite being about an old npm plugin most readers have never heard of. Moved to a dedicated \`## Migrating from the OpenClaw plugin\` section at the bottom, with the actual uninstall commands.

- **Routing page link made clickable.** The Connect a provider step now links directly to \`http://localhost:3001/routing\` instead of just saying "Open the Routing page". Same in the \`get-started.mdx\` Verify tab, which also now links to \`/self-hosted#verify\` for the full curl.

## Test plan

- [x] Followed the entire Quick Start end-to-end on a clean machine: \`curl\` the compose file → \`docker compose up -d\` → wait for boot → log in with demo credentials → confirm dashboard and API endpoints respond
- [x] Both edited pages render 200 on the local Mintlify dev server
- [x] No new MDX parse errors in the dev-server log
- [x] Pre-existing \`AGENTS.md\` parse error (from initial commit) unchanged
- [ ] Mintlify preview build passes in CI