### PR TITLE
Self-hosted docs: add install.sh, broaden positioning to personal agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Source for the [Manifest documentation site](https://manifest.build), built with [Mintlify](https://mintlify.com).
 
-Manifest is an open-source OpenClaw plugin that routes queries to the most cost-effective model and gives you a real-time dashboard to track tokens, costs, and usage.
+Manifest is an open-source LLM router for OpenClaw that routes queries to the most cost-effective model and gives you a real-time dashboard to track tokens, costs, and usage.
 
 ## Local development
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Source for the [Manifest documentation site](https://manifest.build), built with [Mintlify](https://mintlify.com).
 
-Manifest is an open-source LLM router for OpenClaw that routes queries to the most cost-effective model and gives you a real-time dashboard to track tokens, costs, and usage.
+Manifest is an open-source LLM router for personal agents that routes queries to the most cost-effective model and gives you a real-time dashboard to track tokens, costs, and usage.
 
 ## Local development
 

--- a/get-started.mdx
+++ b/get-started.mdx
@@ -27,7 +27,7 @@ icon: "rocket"
         Open the Workspace page and create a new agent.
       </Step>
       <Step title="Follow the install wizard">
-        The dashboard shows setup instructions with everything pre-filled. Follow the steps to add Manifest as a provider in OpenClaw and restart the gateway.
+        The dashboard shows setup instructions with everything pre-filled. Follow the steps to add Manifest as a provider in your agent and restart it.
       </Step>
     </Steps>
   </Tab>

--- a/get-started.mdx
+++ b/get-started.mdx
@@ -33,24 +33,19 @@ icon: "rocket"
   </Tab>
   <Tab title="Self-hosted">
     <Steps>
-      <Step title="Download the compose file">
+      <Step title="Run the installer">
         ```bash
-        curl -O https://raw.githubusercontent.com/mnfst/manifest/main/docker/docker-compose.yml
-        ```
-      </Step>
-      <Step title="Start the services">
-        ```bash
-        docker compose up -d
+        bash <(curl -sSL https://raw.githubusercontent.com/mnfst/manifest/main/docker/install.sh)
         ```
 
-        Give it about 30 seconds to boot.
+        The installer downloads the compose file, generates a secret, and brings up the stack. Give it about 30 seconds to boot.
       </Step>
-      <Step title="Open the dashboard">
-        Go to [http://localhost:3001](http://localhost:3001) and log in with `admin@manifest.build` / `manifest`.
+      <Step title="Create your admin account">
+        Go to [http://localhost:3001](http://localhost:3001). The setup wizard walks you through creating the first admin account.
       </Step>
     </Steps>
 
-    See the full [Self-hosted guide](/self-hosted) for provider setup, custom ports, and environment variables.
+    See the full [Self-hosted guide](/self-hosted) for the manual install path, provider setup, custom ports, and environment variables.
   </Tab>
 </Tabs>
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Manifest"
-description: "Take control of your OpenClaw costs."
+description: "Take control of your personal agent LLM costs."
 icon: "house"
 ---
 
-Manifest is an open-source LLM router for OpenClaw that routes queries to the cheapest model that can handle them. It comes with a dashboard for tracking tokens, costs, and usage.
+Manifest is an open-source LLM router for personal agents that routes queries to the cheapest model that can handle them. It comes with a dashboard for tracking tokens, costs, and usage.
 
 ## Why Manifest
 
@@ -22,7 +22,7 @@ Manifest is an open-source LLM router for OpenClaw that routes queries to the ch
 
 ## How it works
 
-Manifest intercepts each OpenClaw request, scores the query in under 2 ms, assigns a tier (simple / standard / complex / reasoning), and forwards it to the matching model. Token counts, latency, and cost data are captured as requests flow through the router and show up in the dashboard.
+Manifest intercepts each agent request, scores the query in under 2 ms, assigns a tier (simple / standard / complex / reasoning), and forwards it to the matching model. Token counts, latency, and cost data are captured as requests flow through the router and show up in the dashboard.
 
 ## Manifest vs OpenRouter
 
@@ -34,13 +34,12 @@ Manifest intercepts each OpenClaw request, scores the query in under 2 ms, assig
 | **Routing logic** | Transparent, open-source scoring | Black box |
 | **Cost** | Free | Per-token markup |
 | **Dashboard** | Built-in | Separate |
-| **Works with OpenClaw** | Native integration | Requires config |
 
 ## Privacy
 
-Manifest sits between OpenClaw and your LLM providers. In self-hosted mode that middleman runs on your own machine; in Cloud mode it runs on ours. Either way, the actual LLM requests still go out to the provider you configured (Anthropic, OpenAI, etc.).
+Manifest sits between your agent and your LLM providers. In self-hosted mode that middleman runs on your own machine; in Cloud mode it runs on ours. Either way, the actual LLM requests still go out to the provider you configured (Anthropic, OpenAI, etc.).
 
-- **Self-hosted:** Requests go from OpenClaw to your Manifest container to the LLM provider. No Manifest server ever sees them. Routing decisions, token counts, costs, and dashboard data all live in your own PostgreSQL.
+- **Self-hosted:** Requests go from your agent to your Manifest container to the LLM provider. No Manifest server ever sees them. Routing decisions, token counts, costs, and dashboard data all live in your own PostgreSQL.
 - **Cloud:** Requests transit through app.manifest.build on their way to the LLM provider. Only the model name, token counts, and latency are stored for the dashboard. Message content is not persisted.
 
 ## Next step

--- a/self-hosted.mdx
+++ b/self-hosted.mdx
@@ -6,12 +6,43 @@ icon: "docker"
 
 Run the full Manifest stack on your own machine. No Node.js required, just Docker.
 
-## Quick start
+## Quick install (one command)
+
+```bash
+bash <(curl -sSL https://raw.githubusercontent.com/mnfst/manifest/main/docker/install.sh)
+```
+
+The installer downloads the compose file into `./manifest`, generates a fresh `BETTER_AUTH_SECRET`, brings the stack up, and waits for it to become healthy.
+
+<Tip>
+  Prefer to review before running? Download it first:
+
+  ```bash
+  curl -sSLO https://raw.githubusercontent.com/mnfst/manifest/main/docker/install.sh
+  less install.sh
+  bash install.sh
+  ```
+
+  Useful flags: `--dir /opt/mnfst` to install elsewhere, `--dry-run` to preview, `--yes` to skip the confirmation prompt.
+</Tip>
+
+When the installer finishes, open [http://localhost:3001](http://localhost:3001) — the first visit opens a setup wizard that walks you through creating the admin account. Then head to the [Routing](http://localhost:3001/routing) page to add an LLM provider (OpenAI, Anthropic, Gemini, etc.) with your API key.
+
+## Manual install
+
+If you'd rather drive it by hand:
 
 <Steps>
   <Step title="Download the compose file">
     ```bash
     curl -O https://raw.githubusercontent.com/mnfst/manifest/main/docker/docker-compose.yml
+    ```
+  </Step>
+  <Step title="Set a real BETTER_AUTH_SECRET">
+    The compose file ships with a placeholder. Replace it with a real secret before starting the stack:
+
+    ```bash
+    sed -i.bak "s/change-me-to-a-random-32-char-string!!/$(openssl rand -hex 32)/" docker-compose.yml
     ```
   </Step>
   <Step title="Start the services">
@@ -21,11 +52,8 @@ Run the full Manifest stack on your own machine. No Node.js required, just Docke
 
     This starts Manifest and a PostgreSQL database. Give it about 30 seconds to boot on a cold pull — you can watch startup with `docker compose logs -f manifest`.
   </Step>
-  <Step title="Open the dashboard">
-    Go to [http://localhost:3001](http://localhost:3001) and log in with the demo account:
-
-    - **Email:** `admin@manifest.build`
-    - **Password:** `manifest`
+  <Step title="Create your admin account">
+    Go to [http://localhost:3001](http://localhost:3001). The setup wizard at `/setup` walks you through creating the first admin account (minimum 8-character password).
   </Step>
   <Step title="Connect a provider">
     Open the [Routing](http://localhost:3001/routing) page and add an LLM provider (OpenAI, Anthropic, Gemini, etc.) with your API key.
@@ -33,7 +61,7 @@ Run the full Manifest stack on your own machine. No Node.js required, just Docke
 </Steps>
 
 <Warning>
-  **The default compose file is for local testing only.** It ships with `SEED_DATA=true` (populates a fake `demo-agent` with sample token usage), a placeholder `BETTER_AUTH_SECRET`, and the well-known `admin@manifest.build` / `manifest` credentials. Before exposing this instance beyond localhost, set `SEED_DATA=false`, replace the secret with `openssl rand -hex 32`, and change the admin password.
+  Before exposing this instance beyond localhost, double-check that `BETTER_AUTH_SECRET` is a real secret (not the placeholder), and if you enable email verification, set `BETTER_AUTH_URL` to a reachable public URL so the verification links resolve.
 </Warning>
 
 ## Verify
@@ -72,12 +100,12 @@ docker run -d \
   -e DATABASE_URL=postgresql://user:pass@host:5432/manifest \
   -e BETTER_AUTH_SECRET=$(openssl rand -hex 32) \
   -e BETTER_AUTH_URL=http://localhost:3001 \
-  -e NODE_ENV=development \
+  -e AUTO_MIGRATE=true \
   -e MANIFEST_TRUST_LAN=true \
   manifestdotbuild/manifest
 ```
 
-<Info>`NODE_ENV=development` enables automatic database migrations on startup.</Info>
+<Info>`AUTO_MIGRATE=true` runs database migrations on startup.</Info>
 
 ## Environment variables
 
@@ -90,10 +118,10 @@ docker run -d \
 | `BETTER_AUTH_URL` | No | `http://localhost:3001` | Public URL of the app. Set when using a custom port |
 | `PORT` | No | `3001` | Internal server port |
 | `BIND_ADDRESS` | No | `127.0.0.1` | Bind address |
-| `NODE_ENV` | No | `production` | Set `development` for auto-migrations |
+| `NODE_ENV` | No | `production` | Node environment |
 | `CORS_ORIGIN` | No | — | Allowed CORS origin |
 | `API_KEY` | No | — | Internal API key |
-| `SEED_DATA` | No | `false` | Seed demo data on startup |
+| `AUTO_MIGRATE` | No | `true` | Run database migrations on startup |
 | `MANIFEST_TRUST_LAN` | No | `false` | Trust private network IPs for auth (required for Docker) |
 
 **Rate limiting**

--- a/self-hosted.mdx
+++ b/self-hosted.mdx
@@ -30,17 +30,6 @@ Run the full Manifest stack on your own machine. No Node.js required, just Docke
   <Step title="Connect a provider">
     Open the [Routing](http://localhost:3001/routing) page and add an LLM provider (OpenAI, Anthropic, Gemini, etc.) with your API key.
   </Step>
-  <Step title="(Optional) Connect OpenClaw">
-    If you use OpenClaw, point it at this Manifest instance from your terminal:
-
-    ```bash
-    openclaw config set plugins.entries.manifest-model-router.config.devMode true
-    openclaw config set plugins.entries.manifest-model-router.config.endpoint http://localhost:3001
-    openclaw gateway restart
-    ```
-
-    Requires the `openclaw` CLI. Skip this step if you don't use OpenClaw — the dashboard works without it.
-  </Step>
 </Steps>
 
 <Warning>
@@ -49,19 +38,16 @@ Run the full Manifest stack on your own machine. No Node.js required, just Docke
 
 ## Verify
 
-After connecting a provider, send a test request and watch it land in the dashboard.
+After connecting a provider, send a test request and watch it land in the dashboard. Grab your Manifest API key from the dashboard (it starts with `mnfst_`) and run:
 
-- **From OpenClaw** (if you completed the optional step above): trigger any agent request. It should appear on the **Messages** page within a few seconds.
-- **From the API directly:** grab your Manifest API key from the dashboard (it starts with `mnfst_`) and run:
+```bash
+curl -X POST http://localhost:3001/v1/chat/completions \
+  -H "Authorization: Bearer mnfst_YOUR_KEY_HERE" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "manifest/auto", "messages": [{"role": "user", "content": "Hello"}]}'
+```
 
-  ```bash
-  curl -X POST http://localhost:3001/v1/chat/completions \
-    -H "Authorization: Bearer mnfst_YOUR_KEY_HERE" \
-    -H "Content-Type: application/json" \
-    -d '{"model": "manifest/auto", "messages": [{"role": "user", "content": "Hello"}]}'
-  ```
-
-  If the response comes back with `[🦚 Manifest] That doesn't look like a Manifest key`, you're still using the placeholder — replace `mnfst_YOUR_KEY_HERE` with the real key from the dashboard.
+If the response comes back with `[🦚 Manifest] That doesn't look like a Manifest key`, you're still using the placeholder — replace `mnfst_YOUR_KEY_HERE` with the real key from the dashboard.
 
 ## Custom port
 
@@ -148,13 +134,3 @@ docker compose down -v    # Stop and delete all data
 ## Docker Hub
 
 The image is available at [manifestdotbuild/manifest](https://hub.docker.com/r/manifestdotbuild/manifest) on Docker Hub.
-
-## Migrating from the OpenClaw plugin
-
-If you previously ran `openclaw plugins install manifest` (the [`manifest`](https://www.npmjs.com/package/manifest) npm package), it still works but is no longer recommended. Switch to the Docker path above, then uninstall the plugin:
-
-```bash
-openclaw plugins uninstall manifest
-openclaw plugins uninstall manifest-provider
-openclaw gateway restart
-```

--- a/track-usage.mdx
+++ b/track-usage.mdx
@@ -31,7 +31,7 @@ The main dashboard shows:
 | **Duration (ms)** | Round-trip latency |
 | **Model** | Which LLM handled the request |
 | **Routing tier** | simple / standard / complex / reasoning |
-| **Agent name** | The OpenClaw agent that sent the request |
+| **Agent name** | The agent that sent the request |
 
 ## How cost is calculated
 


### PR DESCRIPTION
## Summary

- Broaden Manifest's positioning: it's an LLM router for **personal agents**, not just OpenClaw. Update the tagline, "how it works" copy, the OpenRouter comparison table, and the agent-name / install-wizard language to be agent-agnostic.
- Add `docker/install.sh` as the **primary** self-host path (one-command install that downloads the compose file, generates a secret, and brings up the stack). Manual compose path kept as a fallback.
- Refresh the steps that still referenced the seeded `admin@manifest.build` / `manifest` demo account — first boot now opens a setup wizard at `/setup`, no hardcoded credentials.
- Replace the old `NODE_ENV=development` auto-migration trick with `AUTO_MIGRATE=true` (matches the current compose file).
- Drop the optional **Connect OpenClaw** step and the **Migrating from the OpenClaw plugin** section from `self-hosted.mdx` — the `manifest-model-router` plugin no longer exists.

## Test plan

- [ ] `mintlify dev` renders `self-hosted.mdx` with the new **Quick install** + **Manual install** sections
- [ ] No remaining references to `OpenClaw`, `admin@manifest.build`, `SEED_DATA`, or `manifest-model-router`