### PR TITLE
Fix self-host admin-account step: drop nonexistent /setup wizard

### DIFF
--- a/get-started.mdx
+++ b/get-started.mdx
@@ -41,7 +41,7 @@ icon: "rocket"
         The installer downloads the compose file, generates a secret, and brings up the stack. Give it about 30 seconds to boot.
       </Step>
       <Step title="Create your admin account">
-        Go to [http://localhost:3001](http://localhost:3001). The setup wizard walks you through creating the first admin account.
+        Go to [http://localhost:3001](http://localhost:3001) and sign up. The first account you create becomes the admin — no demo credentials are pre-seeded.
       </Step>
     </Steps>
 

--- a/self-hosted.mdx
+++ b/self-hosted.mdx
@@ -26,7 +26,7 @@ The installer downloads the compose file into `./manifest`, generates a fresh `B
   Useful flags: `--dir /opt/mnfst` to install elsewhere, `--dry-run` to preview, `--yes` to skip the confirmation prompt.
 </Tip>
 
-When the installer finishes, open [http://localhost:3001](http://localhost:3001) — the first visit opens a setup wizard that walks you through creating the admin account. Then head to the [Routing](http://localhost:3001/routing) page to add an LLM provider (OpenAI, Anthropic, Gemini, etc.) with your API key.
+When the installer finishes, open [http://localhost:3001](http://localhost:3001) and sign up for an account — the first account you create on a fresh instance becomes the admin. No demo credentials are seeded; the compose file ships with `SEED_DATA=false`. Then head to the [Routing](http://localhost:3001/routing) page to add an LLM provider (OpenAI, Anthropic, Gemini, etc.) with your API key.
 
 ## Manual install
 
@@ -53,7 +53,7 @@ If you'd rather drive it by hand:
     This starts Manifest and a PostgreSQL database. Give it about 30 seconds to boot on a cold pull — you can watch startup with `docker compose logs -f manifest`.
   </Step>
   <Step title="Create your admin account">
-    Go to [http://localhost:3001](http://localhost:3001). The setup wizard at `/setup` walks you through creating the first admin account (minimum 8-character password).
+    Go to [http://localhost:3001](http://localhost:3001) and sign up. The first account you create becomes the admin — no demo credentials are pre-seeded.
   </Step>
   <Step title="Connect a provider">
     Open the [Routing](http://localhost:3001/routing) page and add an LLM provider (OpenAI, Anthropic, Gemini, etc.) with your API key.


### PR DESCRIPTION
## Summary

The previous docs update described a "setup wizard at \`/setup\`" for creating the first admin account on fresh self-hosted installs. That wizard lives on \`mnfst/manifest@main\` but is **not in the published Docker image** (\`manifestdotbuild/manifest:latest\` is v5.45.1 from 2026-04-09; the wizard was merged at 2026-04-13). Users following the docs hit a \`/setup\` route that returns 404.

### What I verified

Ran \`bash <(curl -sSL .../install.sh)\` against a fresh machine with the stock compose file:

- \`GET /api/v1/setup/status\` → **404 Not Found** (the endpoint does not exist in the running image)
- The v5.45.1 frontend bundle only has \`/login\` and \`/register\` routes — no \`/setup\` route
- The \`admin@manifest.build\` / \`manifest\` demo credentials also don't work (no seed, matches \`SEED_DATA=false\` in the compose file)
- Better Auth's \`POST /api/auth/sign-up/email\` does work, so users can create their first account via the register page

### Fix

Replace the wizard-specific language in \`self-hosted.mdx\` and \`get-started.mdx\` with a generic "sign up" step:

> Go to http://localhost:3001 and sign up. The first account you create becomes the admin — no demo credentials are pre-seeded.

This wording:
- matches what the current image actually shows
- stays accurate when the setup wizard ships in the next release (the wizard is just another "sign up" path)
- preserves the no-demo-credentials framing (the compose file still has \`SEED_DATA=false\`)

## Test plan

- [ ] \`mintlify dev\` renders \`self-hosted.mdx\` and \`get-started.mdx\` without references to a setup wizard
- [ ] No remaining \`/setup\` or "setup wizard" strings in the repo