### PR TITLE
chore: port 2099 default + drop AUTO_MIGRATE + fresher boot copy

### DIFF
--- a/fallback.mdx
+++ b/fallback.mdx
@@ -60,7 +60,7 @@ Fallback models are configured **per tier** in the Manifest dashboard. Each tier
   <Tab title="Self-hosted">
     <Steps>
       <Step title="Open the dashboard">
-        Go to [http://localhost:3001](http://localhost:3001) and navigate to **Routing**.
+        Go to [http://localhost:2099](http://localhost:2099) and navigate to **Routing**.
       </Step>
       <Step title="Select a tier">
         Click on any tier to configure its fallback chain.

--- a/get-started.mdx
+++ b/get-started.mdx
@@ -38,10 +38,10 @@ icon: "rocket"
         bash <(curl -sSL https://raw.githubusercontent.com/mnfst/manifest/main/docker/install.sh)
         ```
 
-        The installer downloads the compose file, generates a secret, and brings up the stack. Give it about 30 seconds to boot.
+        The installer downloads the compose file into `~/manifest`, generates a secret, and brings up the stack. First boot pulls the app image and Postgres, so give it up to a couple of minutes.
       </Step>
       <Step title="Create your admin account">
-        Go to [http://localhost:3001](http://localhost:3001) and sign up. The first account you create becomes the admin — no demo credentials are pre-seeded.
+        Go to [http://localhost:2099](http://localhost:2099) and sign up. The first account you create becomes the admin — no demo credentials are pre-seeded.
       </Step>
     </Steps>
 
@@ -56,7 +56,7 @@ icon: "rocket"
     Open [app.manifest.build](https://app.manifest.build), connect a provider on the Routing page, then send a test request to your agent. It should appear on the Messages page within seconds.
   </Tab>
   <Tab title="Self-hosted">
-    Open [http://localhost:3001](http://localhost:3001), connect a provider on the Routing page, then send a test request. It should appear on the Messages page within seconds. See the [Self-hosted guide](/self-hosted#verify) for the exact verify command.
+    Open [http://localhost:2099](http://localhost:2099), connect a provider on the Routing page, then send a test request. It should appear on the Messages page within seconds. See the [Self-hosted guide](/self-hosted#verify) for the exact verify command.
   </Tab>
 </Tabs>
 

--- a/self-hosted.mdx
+++ b/self-hosted.mdx
@@ -6,17 +6,17 @@ icon: "docker"
 
 Run the full Manifest stack on your own machine. No Node.js required, just Docker.
 
-All three paths end in the same place: a running stack at [http://localhost:3001](http://localhost:3001) where you sign up. The first account you create becomes the admin. No demo credentials are pre-seeded.
+All three paths end in the same place: a running stack at [http://localhost:2099](http://localhost:2099) where you sign up. The first account you create becomes the admin. No demo credentials are pre-seeded.
 
 <Note>
-  The bundled compose file binds port 3001 to `127.0.0.1` only, so the dashboard is reachable on the host machine but not over the LAN. See [Exposing on the LAN](#exposing-on-the-lan) to change this.
+  The bundled compose file binds port 2099 to `127.0.0.1` only, so the dashboard is reachable on the host machine but not over the LAN. See [Exposing on the LAN](#exposing-on-the-lan) to change this.
 </Note>
 
 ## Installation
 
 <Tabs>
   <Tab title="Quick install (recommended)">
-    One command. The installer downloads the compose file, generates a secret, and brings up the stack. Give it about 30 seconds to boot.
+    One command. The installer downloads the compose file into `~/manifest`, generates a secret, and brings up the stack. First boot pulls the app image and Postgres, so give it up to a couple of minutes.
 
     ```bash
     bash <(curl -sSL https://raw.githubusercontent.com/mnfst/manifest/main/docker/install.sh)
@@ -32,7 +32,7 @@ All three paths end in the same place: a running stack at [http://localhost:3001
 
     Useful flags: `--dir <path>` to install elsewhere, `--dry-run` to preview, `--yes` to skip the confirmation prompt.
 
-    When the installer finishes, open [http://localhost:3001](http://localhost:3001) and sign up for an account. Then head to the [Routing](http://localhost:3001/routing) page to add an LLM provider (OpenAI, Anthropic, Gemini, etc.) with your API key.
+    When the installer finishes, open [http://localhost:2099](http://localhost:2099) and sign up for an account. Then head to the [Routing](http://localhost:2099/routing) page to add an LLM provider (OpenAI, Anthropic, Gemini, etc.) with your API key.
   </Tab>
   <Tab title="Docker Compose">
     Same underlying flow as the install script, but you drive it yourself so you can edit the config before booting the stack.
@@ -59,13 +59,13 @@ All three paths end in the same place: a running stack at [http://localhost:3001
         docker compose up -d
         ```
 
-        Give it about 30 seconds to boot on a cold pull — you can watch startup with `docker compose logs -f manifest`.
+        Give it up to a couple of minutes on a cold pull — you can watch startup with `docker compose logs -f manifest`.
       </Step>
       <Step title="Create your admin account">
-        Go to [http://localhost:3001](http://localhost:3001) and sign up. The first account you create becomes the admin.
+        Go to [http://localhost:2099](http://localhost:2099) and sign up. The first account you create becomes the admin.
       </Step>
       <Step title="Connect a provider">
-        Open the [Routing](http://localhost:3001/routing) page and add an LLM provider (OpenAI, Anthropic, Gemini, etc.) with your API key.
+        Open the [Routing](http://localhost:2099/routing) page and add an LLM provider (OpenAI, Anthropic, Gemini, etc.) with your API key.
       </Step>
     </Steps>
 
@@ -78,11 +78,10 @@ All three paths end in the same place: a running stack at [http://localhost:3001
 
     ```bash
     docker run -d \
-      -p 3001:3001 \
+      -p 2099:2099 \
       -e DATABASE_URL=postgresql://user:pass@host:5432/manifest \
       -e BETTER_AUTH_SECRET=$(openssl rand -hex 32) \
-      -e BETTER_AUTH_URL=http://localhost:3001 \
-      -e AUTO_MIGRATE=true \
+      -e BETTER_AUTH_URL=http://localhost:2099 \
       manifestdotbuild/manifest
     ```
 
@@ -91,11 +90,10 @@ All three paths end in the same place: a running stack at [http://localhost:3001
       $secret = -join ((48..57 + 97..122) | Get-Random -Count 64 | ForEach-Object { [char]$_ })
 
       docker run -d `
-        -p 3001:3001 `
+        -p 2099:2099 `
         -e DATABASE_URL=postgresql://user:pass@host:5432/manifest `
         -e BETTER_AUTH_SECRET=$secret `
-        -e BETTER_AUTH_URL=http://localhost:3001 `
-        -e AUTO_MIGRATE=true `
+        -e BETTER_AUTH_URL=http://localhost:2099 `
         manifestdotbuild/manifest
       ```
     </Accordion>
@@ -105,16 +103,13 @@ All three paths end in the same place: a running stack at [http://localhost:3001
 
       ```cmd
       docker run -d ^
-        -p 3001:3001 ^
+        -p 2099:2099 ^
         -e DATABASE_URL=postgresql://user:pass@host:5432/manifest ^
         -e BETTER_AUTH_SECRET=<your-64-char-secret> ^
-        -e BETTER_AUTH_URL=http://localhost:3001 ^
-        -e AUTO_MIGRATE=true ^
+        -e BETTER_AUTH_URL=http://localhost:2099 ^
         manifestdotbuild/manifest
       ```
     </Accordion>
-
-    <Info>`AUTO_MIGRATE=true` runs database migrations on first boot.</Info>
   </Tab>
 </Tabs>
 
@@ -123,7 +118,7 @@ All three paths end in the same place: a running stack at [http://localhost:3001
 After connecting a provider, send a test request and watch it land in the dashboard. Grab your Manifest API key from the dashboard (it starts with `mnfst_`) and run:
 
 ```bash
-curl -X POST http://localhost:3001/v1/chat/completions \
+curl -X POST http://localhost:2099/v1/chat/completions \
   -H "Authorization: Bearer mnfst_YOUR_KEY_HERE" \
   -H "Content-Type: application/json" \
   -d '{"model": "manifest/auto", "messages": [{"role": "user", "content": "Hello"}]}'
@@ -143,11 +138,11 @@ cosign verify manifestdotbuild/manifest:<version> \
 
 ## Custom port
 
-If port 3001 is taken, change both the mapping and `BETTER_AUTH_URL`:
+If port 2099 is taken, change both the mapping and `BETTER_AUTH_URL`:
 
 ```bash
 docker run -d \
-  -p 8080:3001 \
+  -p 8080:2099 \
   -e BETTER_AUTH_URL=http://localhost:8080 \
   ...
 ```
@@ -156,7 +151,7 @@ Or in `docker-compose.yml`:
 
 ```yaml
 ports:
-  - '127.0.0.1:8080:3001'
+  - '127.0.0.1:8080:2099'
 ```
 
 ...and in `.env`:
@@ -167,16 +162,20 @@ BETTER_AUTH_URL=http://localhost:8080
 
 <Warning>If you see an "Invalid origin" error on the login page, `BETTER_AUTH_URL` doesn't match the URL you're accessing the dashboard on. The host matters as much as the port.</Warning>
 
+<Note>
+  **Upgrading from a pre-2099 install?** Your existing stack keeps running on port 3001 with no changes — the backend's own fallback is still `3001`, so the new image works against your old compose file. If you want to refresh your compose file but stay on the legacy port (to avoid reconfiguring OAuth callbacks, reverse proxies, or bookmarks), set `PORT=3001` in `.env` and the bundled compose file will honour it for both the host binding and the internal listener.
+</Note>
+
 ## Exposing on the LAN
 
-By default the compose file binds port 3001 to `127.0.0.1` only. The dashboard is reachable from the host but not from other machines on the network. To expose it on the LAN:
+By default the compose file binds port 2099 to `127.0.0.1` only. The dashboard is reachable from the host but not from other machines on the network. To expose it on the LAN:
 
 <Steps>
   <Step title="Change the port binding">
-    Edit `docker-compose.yml` and change the `ports` line from `"127.0.0.1:3001:3001"` to `"3001:3001"`.
+    Edit `docker-compose.yml` and change the `ports` line from `"127.0.0.1:2099:2099"` to `"2099:2099"`.
   </Step>
   <Step title="Set BETTER_AUTH_URL">
-    In `.env`, set `BETTER_AUTH_URL` to the host you'll reach the dashboard on, e.g. `http://192.168.1.20:3001` or `https://manifest.mydomain.com`. This must match the URL in the browser or Better Auth will reject the login with "Invalid origin".
+    In `.env`, set `BETTER_AUTH_URL` to the host you'll reach the dashboard on, e.g. `http://192.168.1.20:2099` or `https://manifest.mydomain.com`. This must match the URL in the browser or Better Auth will reject the login with "Invalid origin".
   </Step>
   <Step title="Apply">
     ```bash
@@ -243,8 +242,8 @@ docker compose down -v    # destroys all data
 |----------|----------|---------|-------------|
 | `DATABASE_URL` | Yes | — | PostgreSQL connection string |
 | `BETTER_AUTH_SECRET` | Yes | — | Session signing secret (min 32 chars) |
-| `BETTER_AUTH_URL` | No | `http://localhost:3001` | Public URL. Set this when using a custom port |
-| `PORT` | No | `3001` | Internal server port |
+| `BETTER_AUTH_URL` | No | `http://localhost:2099` | Public URL. Set this when using a custom port |
+| `PORT` | No | `2099` | Internal server port |
 | `NODE_ENV` | No | `production` | Node environment |
 | `SEED_DATA` | No | `false` | Seed demo data on startup |
 
@@ -256,7 +255,6 @@ docker compose down -v    # destroys all data
   | `BIND_ADDRESS` | `127.0.0.1` | Bind address |
   | `CORS_ORIGIN` | — | Allowed CORS origin |
   | `API_KEY` | — | Internal API key |
-  | `AUTO_MIGRATE` | `true` | Run database migrations on startup |
 
   **Rate limiting**
 


### PR DESCRIPTION
Catches the docs up to three changes that landed (or are landing) in [mnfst/manifest](https://github.com/mnfst/manifest):

## Changes

### 1. Default port 2099 for new installs

Tracks [mnfst/manifest#1649](https://github.com/mnfst/manifest/pull/1649). New \`install.sh\` runs land on 2099 by default. Existing installs keep working on 3001 with no changes — the backend's own fallback is still 3001, so the new image works against an unchanged compose file.

Replaced every \`localhost:3001\` / \`-p 3001:3001\` / \`BETTER_AUTH_URL=...:3001\` / \`PORT=3001\` with \`2099\` across:
- \`fallback.mdx\` (1 hit)
- \`get-started.mdx\` (2 hits)
- \`self-hosted.mdx\` (most of the bulk — installation, custom port, exposing on the LAN, env-var table)

Added a \`<Note>\` in the **Custom port** section spelling out the upgrade path:

> **Upgrading from a pre-2099 install?** Your existing stack keeps running on port 3001 with no changes — the backend's own fallback is still 3001, so the new image works against your old compose file. If you want to refresh your compose file but stay on the legacy port (to avoid reconfiguring OAuth callbacks, reverse proxies, or bookmarks), set \`PORT=3001\` in \`.env\` and the bundled compose file will honour it for both the host binding and the internal listener.

### 2. Drop \`AUTO_MIGRATE=true\`

[mnfst/manifest#1638](https://github.com/mnfst/manifest/pull/1638) made TypeORM migrations run unconditionally on boot. The env var is no longer needed (and is a no-op). Removed:
- \`-e AUTO_MIGRATE=true \\\`/\` \`/\`^\` lines in the three Docker Run examples (Linux/macOS, PowerShell, CMD)
- The \`<Info>\`AUTO_MIGRATE=true\` runs database migrations on first boot.</Info>\` callout
- The \`AUTO_MIGRATE\` row in the additional env-vars table

### 3. \"About 30 seconds to boot\" → \"up to a couple of minutes\"

The installer itself polls health for up to 120s. \"30 seconds\" undersells cold-pull time and was making people think something was broken. Matches the corresponding fix in [mnfst/manifest#1649](https://github.com/mnfst/manifest/pull/1649)'s \`install.sh\` and \`README.md\`. Updated in three places (self-hosted intro, self-hosted Docker Run \"first boot\", get-started).

### 4. Surface the new default install dir

The install script now defaults to \`~/manifest\` (was \`./manifest\`) so the one-liner doesn't litter random working directories. Mentioned in the get-started and self-hosted \"installer\" blurbs.

## Verification

- \`grep -rn '3001\\|AUTO_MIGRATE\\|30 seconds' --include=\"*.mdx\" --include=\"*.md\" .\` returns nothing
- All three \`.mdx\` files render without MDX/JSX syntax errors (component usage unchanged: \`<Note>\`, \`<Warning>\`, \`<Info>\`, \`<Accordion>\`, \`<Tabs>\`, \`<Tab>\`, \`<Steps>\`, \`<Step>\` all match the patterns already used elsewhere)