### PR TITLE
docs: add error encyclopedia (M001-M500)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -112,27 +112,8 @@
               "reference/api",
               "reference/headers",
               "reference/environment-variables",
-              "reference/glossary"
-            ]
-          },
-          {
-            "group": "Errors",
-            "pages": [
-              "errors",
-              "errors/M001",
-              "errors/M002",
-              "errors/M003",
-              "errors/M004",
-              "errors/M005",
-              "errors/M100",
-              "errors/M101",
-              "errors/M200",
-              "errors/M201",
-              "errors/M202",
-              "errors/M203",
-              "errors/M300",
-              "errors/M301",
-              "errors/M500"
+              "reference/glossary",
+              "errors"
             ]
           }
         ]

--- a/docs.json
+++ b/docs.json
@@ -114,6 +114,26 @@
               "reference/environment-variables",
               "reference/glossary"
             ]
+          },
+          {
+            "group": "Errors",
+            "pages": [
+              "errors",
+              "errors/M001",
+              "errors/M002",
+              "errors/M003",
+              "errors/M004",
+              "errors/M005",
+              "errors/M100",
+              "errors/M101",
+              "errors/M200",
+              "errors/M201",
+              "errors/M202",
+              "errors/M203",
+              "errors/M300",
+              "errors/M301",
+              "errors/M500"
+            ]
           }
         ]
       }

--- a/errors.mdx
+++ b/errors.mdx
@@ -11,7 +11,7 @@ When Manifest blocks or rejects a request, the response message starts with a co
 
 ```text
 [🦚 Manifest M100] No anthropic API key yet. Add one here: https://app.manifest.build/...
-See https://manifest.build/errors/M100
+See https://manifest.build/docs/errors/M100
 ```
 
 Look up the code below to see what it means and how to fix it.

--- a/errors.mdx
+++ b/errors.mdx
@@ -1,0 +1,66 @@
+---
+title: "Error encyclopedia"
+sidebarTitle: "Overview"
+description: "Stable codes for every user-facing error Manifest throws — what they mean and how to fix them."
+icon: "circle-alert"
+keywords:
+  ["error codes", "Manifest errors", "M001", "troubleshooting", "proxy errors"]
+---
+
+When Manifest blocks or rejects a request, the response message starts with a code in square brackets:
+
+```text
+[🦚 Manifest M100] No anthropic API key yet. Add one here: https://app.manifest.build/...
+See https://manifest.build/errors/M100
+```
+
+Look up the code below to see what it means and how to fix it.
+
+## Authentication (M001–M005)
+
+These fire when the bearer token on `/v1/chat/completions` is missing or wrong.
+
+| Code | What |
+|------|------|
+| [M001](/errors/M001) | Missing Authorization header |
+| [M002](/errors/M002) | Empty Bearer token |
+| [M003](/errors/M003) | Invalid key format |
+| [M004](/errors/M004) | Key expired |
+| [M005](/errors/M005) | Key not recognized |
+
+## Providers (M100–M101)
+
+Your key is fine, but no provider credentials are wired up.
+
+| Code | What |
+|------|------|
+| [M100](/errors/M100) | Provider API key missing |
+| [M101](/errors/M101) | No providers configured |
+
+## Limits (M200–M203)
+
+You hit a usage cap or rate limit.
+
+| Code | What |
+|------|------|
+| [M200](/errors/M200) | Usage limit exceeded |
+| [M201](/errors/M201) | Per-user rate limit exceeded |
+| [M202](/errors/M202) | Per-IP rate limit exceeded |
+| [M203](/errors/M203) | Concurrency limit exceeded |
+
+## Validation (M300–M301)
+
+The request body is malformed.
+
+| Code | What |
+|------|------|
+| [M300](/errors/M300) | Missing messages array |
+| [M301](/errors/M301) | Messages array too long |
+
+## Server (M500)
+
+Manifest itself broke.
+
+| Code | What |
+|------|------|
+| [M500](/errors/M500) | Internal server error |

--- a/errors.mdx
+++ b/errors.mdx
@@ -1,9 +1,10 @@
 ---
-title: "Errors"
-description: "Stable codes for every user-facing error Manifest throws — what they mean and how to fix them."
+title: "Manifest error codes"
+sidebarTitle: "Errors"
+description: "Reference for every Manifest proxy error code (M001-M500). What you saw, why it happened, and how to fix it. Covers auth, providers, limits, validation."
 icon: "circle-alert"
 keywords:
-  ["error codes", "Manifest errors", "M001", "troubleshooting", "proxy errors"]
+  ["Manifest error codes", "M001", "M100", "M200", "M500", "OpenAI compatible errors", "401 Unauthorized", "429 Too Many Requests", "Bearer token error", "chat completions error", "troubleshooting", "proxy errors"]
 ---
 
 When Manifest blocks or rejects a request, the response message starts with a code in square brackets:
@@ -17,49 +18,49 @@ Look up the code below to see what it means and how to fix it.
 
 ## Authentication (M001–M005)
 
-These fire when the bearer token on `/v1/chat/completions` is missing or wrong.
+These fire when the bearer token on `/v1/chat/completions` is missing or wrong. They surface as HTTP 401 to non-chat clients.
 
 | Code | What |
 |------|------|
-| [M001](/errors/M001) | Missing Authorization header |
-| [M002](/errors/M002) | Empty Bearer token |
-| [M003](/errors/M003) | Invalid key format |
-| [M004](/errors/M004) | Key expired |
-| [M005](/errors/M005) | Key not recognized |
+| [M001: Missing Authorization header](/errors/M001) | No `Authorization` header on the request |
+| [M002: Empty Bearer token](/errors/M002) | Header present, token after `Bearer ` is blank |
+| [M003: Invalid key format](/errors/M003) | Token doesn't start with `mnfst_` |
+| [M004: Key expired](/errors/M004) | Key past its expiration date |
+| [M005: Key not recognized](/errors/M005) | No matching agent for this key |
 
 ## Providers (M100–M101)
 
-Your key is fine, but no provider credentials are wired up.
+Your key is fine, but no provider credentials are wired up. See [Routing](/routing) and [API key providers](/providers/api-key-providers).
 
 | Code | What |
 |------|------|
-| [M100](/errors/M100) | Provider API key missing |
-| [M101](/errors/M101) | No providers configured |
+| [M100: Provider API key missing](/errors/M100) | Routing picked a provider you haven't connected |
+| [M101: No providers configured](/errors/M101) | Agent has zero providers connected |
 
 ## Limits (M200–M203)
 
-You hit a usage cap or rate limit.
+You hit a usage cap or rate limit. They surface as HTTP 429. See [Set limits](/set-limits).
 
 | Code | What |
 |------|------|
-| [M200](/errors/M200) | Usage limit exceeded |
-| [M201](/errors/M201) | Per-user rate limit exceeded |
-| [M202](/errors/M202) | Per-IP rate limit exceeded |
-| [M203](/errors/M203) | Concurrency limit exceeded |
+| [M200: Usage limit exceeded](/errors/M200) | Cost or message-count limit you set was crossed |
+| [M201: Per-user rate limit exceeded](/errors/M201) | More than 200 requests/minute from one user |
+| [M202: Per-IP rate limit exceeded](/errors/M202) | More than 500 requests/minute from one IP |
+| [M203: Concurrency limit exceeded](/errors/M203) | More than 10 in-flight requests at once |
 
 ## Validation (M300–M301)
 
-The request body is malformed.
+The request body is malformed. They surface as HTTP 400.
 
 | Code | What |
 |------|------|
-| [M300](/errors/M300) | Missing messages array |
-| [M301](/errors/M301) | Messages array too long |
+| [M300: Missing messages array](/errors/M300) | Body has no `messages` array, or it's empty |
+| [M301: Messages array too long](/errors/M301) | More than 1000 messages in a single request |
 
 ## Server (M500)
 
-Manifest itself broke.
+Manifest itself broke. Surfaces as HTTP 500.
 
 | Code | What |
 |------|------|
-| [M500](/errors/M500) | Internal server error |
+| [M500: Internal server error](/errors/M500) | Unhandled error in the proxy pipeline |

--- a/errors.mdx
+++ b/errors.mdx
@@ -1,6 +1,5 @@
 ---
-title: "Error encyclopedia"
-sidebarTitle: "Overview"
+title: "Errors"
 description: "Stable codes for every user-facing error Manifest throws — what they mean and how to fix them."
 icon: "circle-alert"
 keywords:

--- a/errors/M001.mdx
+++ b/errors/M001.mdx
@@ -11,7 +11,7 @@ keywords:
 
 ```text
 [🦚 Manifest M001] Missing the Authorization header. Set it to "Bearer mnfst_<your-key>".
-See https://manifest.build/errors/M001
+See https://manifest.build/docs/errors/M001
 ```
 
 ## Why it happened

--- a/errors/M001.mdx
+++ b/errors/M001.mdx
@@ -1,0 +1,31 @@
+---
+title: "M001 — Missing Authorization header"
+sidebarTitle: "M001"
+description: "Manifest received a request without an Authorization header on /v1/chat/completions."
+icon: "key-round"
+keywords:
+  ["M001", "Authorization header", "Bearer", "missing header", "Manifest auth error"]
+---
+
+## What you saw
+
+```text
+[🦚 Manifest M001] Missing the Authorization header. Set it to "Bearer mnfst_<your-key>".
+See https://manifest.build/errors/M001
+```
+
+## Why it happened
+
+Your client sent a request to `/v1/chat/completions` without an `Authorization` header. Manifest authenticates every request against an agent API key, so the header is mandatory.
+
+## How to fix it
+
+1. Grab your agent's key from the [dashboard](https://app.manifest.build) (Workspace → agent → key).
+2. Add the header to every request: `Authorization: Bearer mnfst_<your-key>`.
+3. If you're using an SDK, set the API key in its config rather than constructing the header by hand.
+
+## Related
+
+- [M002 — Empty Bearer token](/errors/M002)
+- [M003 — Invalid key format](/errors/M003)
+- [M005 — Key not recognized](/errors/M005)

--- a/errors/M001.mdx
+++ b/errors/M001.mdx
@@ -1,10 +1,10 @@
 ---
-title: "M001 — Missing Authorization header"
+title: "M001: Missing Authorization header"
 sidebarTitle: "M001"
-description: "Manifest received a request without an Authorization header on /v1/chat/completions."
+description: "Manifest error M001 fires when /v1/chat/completions is called without an Authorization header. Returns HTTP 401. Fix: send `Authorization: Bearer mnfst_<key>`."
 icon: "key-round"
 keywords:
-  ["M001", "Authorization header", "Bearer", "missing header", "Manifest auth error"]
+  ["M001", "Manifest M001", "Authorization header missing", "Bearer token", "401 Unauthorized", "OpenAI compatible 401", "Manifest auth error", "chat completions authorization"]
 ---
 
 ## What you saw
@@ -16,16 +16,18 @@ See https://manifest.build/docs/errors/M001
 
 ## Why it happened
 
-Your client sent a request to `/v1/chat/completions` without an `Authorization` header. Manifest authenticates every request against an agent API key, so the header is mandatory.
+Your client called `/v1/chat/completions` without an `Authorization` header. Manifest checks an agent API key on every request, so the header has to be there.
 
 ## How to fix it
 
-1. Grab your agent's key from the [dashboard](https://app.manifest.build) (Workspace → agent → key).
+1. Grab your agent's key from the [dashboard](https://app.manifest.build) (Workspace, agent, key).
 2. Add the header to every request: `Authorization: Bearer mnfst_<your-key>`.
-3. If you're using an SDK, set the API key in its config rather than constructing the header by hand.
+3. If you're using an SDK, set the API key in its config instead of building the header by hand.
 
 ## Related
 
-- [M002 — Empty Bearer token](/errors/M002)
-- [M003 — Invalid key format](/errors/M003)
-- [M005 — Key not recognized](/errors/M005)
+- [M002: Empty Bearer token](/errors/M002)
+- [M003: Invalid key format](/errors/M003)
+- [M004: Key expired](/errors/M004)
+- [M005: Key not recognized](/errors/M005)
+- [All error codes](/errors)

--- a/errors/M002.mdx
+++ b/errors/M002.mdx
@@ -11,7 +11,7 @@ keywords:
 
 ```text
 [🦚 Manifest M002] The Bearer token is empty. Paste your Manifest key into it.
-See https://manifest.build/errors/M002
+See https://manifest.build/docs/errors/M002
 ```
 
 ## Why it happened

--- a/errors/M002.mdx
+++ b/errors/M002.mdx
@@ -1,0 +1,30 @@
+---
+title: "M002 — Empty Bearer token"
+sidebarTitle: "M002"
+description: "Manifest received an Authorization header with an empty Bearer token."
+icon: "key-round"
+keywords:
+  ["M002", "empty token", "Bearer", "Manifest auth error"]
+---
+
+## What you saw
+
+```text
+[🦚 Manifest M002] The Bearer token is empty. Paste your Manifest key into it.
+See https://manifest.build/errors/M002
+```
+
+## Why it happened
+
+The `Authorization` header was present but the token after `Bearer ` is blank. Common causes: an env var that didn't expand (`Bearer $MNFST_KEY` with `MNFST_KEY` unset), or a config field saved without a value.
+
+## How to fix it
+
+1. Print the value your client sends just before the request to confirm the token is empty.
+2. Check your env vars or config file for the key. If you don't have one, generate it from the [dashboard](https://app.manifest.build).
+3. Set `Authorization: Bearer mnfst_<your-key>` and retry.
+
+## Related
+
+- [M001 — Missing Authorization header](/errors/M001)
+- [M003 — Invalid key format](/errors/M003)

--- a/errors/M002.mdx
+++ b/errors/M002.mdx
@@ -1,10 +1,10 @@
 ---
-title: "M002 — Empty Bearer token"
+title: "M002: Empty Bearer token"
 sidebarTitle: "M002"
-description: "Manifest received an Authorization header with an empty Bearer token."
+description: "Manifest error M002 fires when the Authorization header is set but the Bearer token is blank. Often an unexpanded env var. Returns HTTP 401."
 icon: "key-round"
 keywords:
-  ["M002", "empty token", "Bearer", "Manifest auth error"]
+  ["M002", "Manifest M002", "empty Bearer token", "blank token", "401 Unauthorized", "MNFST_KEY env var", "Manifest auth error", "OpenAI compatible 401"]
 ---
 
 ## What you saw
@@ -16,15 +16,17 @@ See https://manifest.build/docs/errors/M002
 
 ## Why it happened
 
-The `Authorization` header was present but the token after `Bearer ` is blank. Common causes: an env var that didn't expand (`Bearer $MNFST_KEY` with `MNFST_KEY` unset), or a config field saved without a value.
+The `Authorization` header is there, but the token after `Bearer ` is blank. The usual cause is an env var that didn't expand (`Bearer $MNFST_KEY` with `MNFST_KEY` unset), or a config field saved without a value.
 
 ## How to fix it
 
-1. Print the value your client sends just before the request to confirm the token is empty.
-2. Check your env vars or config file for the key. If you don't have one, generate it from the [dashboard](https://app.manifest.build).
+1. Log the value your client sends right before the request to confirm the token is actually empty.
+2. Check your env vars or config file. If the key is missing, generate one from the [dashboard](https://app.manifest.build).
 3. Set `Authorization: Bearer mnfst_<your-key>` and retry.
 
 ## Related
 
-- [M001 — Missing Authorization header](/errors/M001)
-- [M003 — Invalid key format](/errors/M003)
+- [M001: Missing Authorization header](/errors/M001)
+- [M003: Invalid key format](/errors/M003)
+- [M005: Key not recognized](/errors/M005)
+- [All error codes](/errors)

--- a/errors/M003.mdx
+++ b/errors/M003.mdx
@@ -11,7 +11,7 @@ keywords:
 
 ```text
 [🦚 Manifest M003] That doesn't look right. Manifest keys start with "mnfst_". Grab yours from the dashboard.
-See https://manifest.build/errors/M003
+See https://manifest.build/docs/errors/M003
 ```
 
 ## Why it happened

--- a/errors/M003.mdx
+++ b/errors/M003.mdx
@@ -1,0 +1,31 @@
+---
+title: "M003 — Invalid key format"
+sidebarTitle: "M003"
+description: "The Bearer token doesn't have the expected mnfst_ prefix."
+icon: "key-round"
+keywords:
+  ["M003", "invalid key format", "mnfst_", "Manifest auth error"]
+---
+
+## What you saw
+
+```text
+[🦚 Manifest M003] That doesn't look right. Manifest keys start with "mnfst_". Grab yours from the dashboard.
+See https://manifest.build/errors/M003
+```
+
+## Why it happened
+
+Manifest API keys always start with `mnfst_`. The token you sent has a different prefix, which usually means you pasted a provider key (OpenAI, Anthropic, etc.) into the wrong field.
+
+## How to fix it
+
+1. Open the [dashboard](https://app.manifest.build) and copy your agent's key. It will look like `mnfst_xxxxxxxxxxxx`.
+2. Replace the token in your client's config and retry.
+3. Provider keys (e.g. OpenAI's `sk-...`) belong on the **Routing** page, not in the Authorization header.
+
+## Related
+
+- [M001 — Missing Authorization header](/errors/M001)
+- [M005 — Key not recognized](/errors/M005)
+- [M100 — Provider API key missing](/errors/M100)

--- a/errors/M003.mdx
+++ b/errors/M003.mdx
@@ -1,10 +1,10 @@
 ---
-title: "M003 — Invalid key format"
+title: "M003: Invalid key format"
 sidebarTitle: "M003"
-description: "The Bearer token doesn't have the expected mnfst_ prefix."
+description: "Manifest error M003 fires when the Bearer token doesn't start with mnfst_. Often a provider key (sk-...) pasted in the wrong field. Returns HTTP 401."
 icon: "key-round"
 keywords:
-  ["M003", "invalid key format", "mnfst_", "Manifest auth error"]
+  ["M003", "Manifest M003", "invalid API key format", "mnfst_ prefix", "wrong API key", "OpenAI sk- key", "401 Unauthorized", "Manifest auth error"]
 ---
 
 ## What you saw
@@ -16,16 +16,18 @@ See https://manifest.build/docs/errors/M003
 
 ## Why it happened
 
-Manifest API keys always start with `mnfst_`. The token you sent has a different prefix, which usually means you pasted a provider key (OpenAI, Anthropic, etc.) into the wrong field.
+Manifest keys always start with `mnfst_`. Your token has a different prefix, which almost always means a provider key (OpenAI, Anthropic, etc.) got pasted into the wrong field.
 
 ## How to fix it
 
-1. Open the [dashboard](https://app.manifest.build) and copy your agent's key. It will look like `mnfst_xxxxxxxxxxxx`.
+1. Open the [dashboard](https://app.manifest.build) and copy your agent's key. It looks like `mnfst_xxxxxxxxxxxx`.
 2. Replace the token in your client's config and retry.
-3. Provider keys (e.g. OpenAI's `sk-...`) belong on the **Routing** page, not in the Authorization header.
+3. Provider keys (OpenAI's `sk-...`, etc.) belong on the **Routing** page, not in the Authorization header.
 
 ## Related
 
-- [M001 — Missing Authorization header](/errors/M001)
-- [M005 — Key not recognized](/errors/M005)
-- [M100 — Provider API key missing](/errors/M100)
+- [M001: Missing Authorization header](/errors/M001)
+- [M005: Key not recognized](/errors/M005)
+- [M100: Provider API key missing](/errors/M100)
+- [API key providers](/providers/api-key-providers)
+- [All error codes](/errors)

--- a/errors/M004.mdx
+++ b/errors/M004.mdx
@@ -1,0 +1,29 @@
+---
+title: "M004 — Key expired"
+sidebarTitle: "M004"
+description: "The Manifest API key you sent has passed its expiration date."
+icon: "key-round"
+keywords:
+  ["M004", "key expired", "rotation", "Manifest auth error"]
+---
+
+## What you saw
+
+```text
+[🦚 Manifest M004] This key has expired. Generate a new one here
+See https://manifest.build/errors/M004
+```
+
+## Why it happened
+
+Manifest keys can be set to expire on a date. The one you sent is past that date, so it no longer authenticates requests.
+
+## How to fix it
+
+1. Open the [dashboard](https://app.manifest.build) and rotate or generate a new key for the agent.
+2. Update your client's config with the new value.
+3. If you didn't expect an expiration, check your agent's settings and remove the date.
+
+## Related
+
+- [M005 — Key not recognized](/errors/M005)

--- a/errors/M004.mdx
+++ b/errors/M004.mdx
@@ -1,10 +1,10 @@
 ---
-title: "M004 — Key expired"
+title: "M004: Key expired"
 sidebarTitle: "M004"
-description: "The Manifest API key you sent has passed its expiration date."
+description: "Manifest error M004 fires when the API key you sent is past its expiration date. Returns HTTP 401. Fix: rotate the key in the dashboard."
 icon: "key-round"
 keywords:
-  ["M004", "key expired", "rotation", "Manifest auth error"]
+  ["M004", "Manifest M004", "API key expired", "key rotation", "401 Unauthorized", "Manifest auth error", "expired token"]
 ---
 
 ## What you saw
@@ -16,14 +16,16 @@ See https://manifest.build/docs/errors/M004
 
 ## Why it happened
 
-Manifest keys can be set to expire on a date. The one you sent is past that date, so it no longer authenticates requests.
+Manifest keys can carry an expiration date. Yours is past that date, so it no longer authenticates anything.
 
 ## How to fix it
 
-1. Open the [dashboard](https://app.manifest.build) and rotate or generate a new key for the agent.
+1. Open the [dashboard](https://app.manifest.build) and rotate or generate a new key for this agent.
 2. Update your client's config with the new value.
-3. If you didn't expect an expiration, check your agent's settings and remove the date.
+3. If you didn't intend the key to expire, edit the agent's settings and clear the date.
 
 ## Related
 
-- [M005 — Key not recognized](/errors/M005)
+- [M005: Key not recognized](/errors/M005)
+- [M001: Missing Authorization header](/errors/M001)
+- [All error codes](/errors)

--- a/errors/M004.mdx
+++ b/errors/M004.mdx
@@ -11,7 +11,7 @@ keywords:
 
 ```text
 [🦚 Manifest M004] This key has expired. Generate a new one here
-See https://manifest.build/errors/M004
+See https://manifest.build/docs/errors/M004
 ```
 
 ## Why it happened

--- a/errors/M005.mdx
+++ b/errors/M005.mdx
@@ -1,0 +1,30 @@
+---
+title: "M005 — Key not recognized"
+sidebarTitle: "M005"
+description: "Manifest doesn't recognize the API key you sent. It may have been rotated or deleted."
+icon: "key-round"
+keywords:
+  ["M005", "invalid API key", "rotated key", "deleted key", "Manifest auth error"]
+---
+
+## What you saw
+
+```text
+[🦚 Manifest M005] I don't recognize this key. It might have been rotated or deleted. Grab the current one from the dashboard.
+See https://manifest.build/errors/M005
+```
+
+## Why it happened
+
+The token format looks correct (`mnfst_...`) but no matching agent exists in our records. Either the key was rotated and your client still has the old value, the agent was deleted, or you copied the key from a different workspace.
+
+## How to fix it
+
+1. Open the [dashboard](https://app.manifest.build), find your agent, and copy the current key.
+2. Paste it into your client's config. If the agent is gone, create a new one and copy its key.
+3. If you self-host Manifest, confirm your client is pointing at the right backend URL.
+
+## Related
+
+- [M003 — Invalid key format](/errors/M003)
+- [M004 — Key expired](/errors/M004)

--- a/errors/M005.mdx
+++ b/errors/M005.mdx
@@ -1,10 +1,10 @@
 ---
-title: "M005 — Key not recognized"
+title: "M005: Key not recognized"
 sidebarTitle: "M005"
-description: "Manifest doesn't recognize the API key you sent. It may have been rotated or deleted."
+description: "Manifest error M005 fires when the mnfst_ key has the right shape but no matching agent exists. Often a rotated or deleted key. Returns HTTP 401."
 icon: "key-round"
 keywords:
-  ["M005", "invalid API key", "rotated key", "deleted key", "Manifest auth error"]
+  ["M005", "Manifest M005", "invalid API key", "rotated key", "deleted agent", "401 Unauthorized", "key not found", "Manifest auth error"]
 ---
 
 ## What you saw
@@ -16,15 +16,18 @@ See https://manifest.build/docs/errors/M005
 
 ## Why it happened
 
-The token format looks correct (`mnfst_...`) but no matching agent exists in our records. Either the key was rotated and your client still has the old value, the agent was deleted, or you copied the key from a different workspace.
+The token shape is right (`mnfst_...`) but no matching agent exists. Usually that means the key was rotated and your client still has the old value, or the agent itself was deleted, or you copied a key from a different workspace.
 
 ## How to fix it
 
 1. Open the [dashboard](https://app.manifest.build), find your agent, and copy the current key.
 2. Paste it into your client's config. If the agent is gone, create a new one and copy its key.
-3. If you self-host Manifest, confirm your client is pointing at the right backend URL.
+3. On a self-hosted install, double-check that your client is hitting the right backend URL.
 
 ## Related
 
-- [M003 — Invalid key format](/errors/M003)
-- [M004 — Key expired](/errors/M004)
+- [M003: Invalid key format](/errors/M003)
+- [M004: Key expired](/errors/M004)
+- [M001: Missing Authorization header](/errors/M001)
+- [Self-hosted setup](/self-hosted)
+- [All error codes](/errors)

--- a/errors/M005.mdx
+++ b/errors/M005.mdx
@@ -11,7 +11,7 @@ keywords:
 
 ```text
 [🦚 Manifest M005] I don't recognize this key. It might have been rotated or deleted. Grab the current one from the dashboard.
-See https://manifest.build/errors/M005
+See https://manifest.build/docs/errors/M005
 ```
 
 ## Why it happened

--- a/errors/M100.mdx
+++ b/errors/M100.mdx
@@ -1,10 +1,10 @@
 ---
-title: "M100 — Provider API key missing"
+title: "M100: Provider API key missing"
 sidebarTitle: "M100"
-description: "Manifest routed your request to a provider, but you haven't connected an API key for it yet."
+description: "Manifest error M100 fires when routing picks a provider that has no API key for this agent (OpenAI, Anthropic, Gemini, OpenRouter, etc). Fix: add the key in Routing."
 icon: "plug-zap"
 keywords:
-  ["M100", "provider key", "no API key", "OpenAI key", "Anthropic key", "Manifest routing"]
+  ["M100", "Manifest M100", "provider API key missing", "no OpenAI key", "no Anthropic key", "no Gemini key", "OpenRouter key", "Manifest routing", "provider credentials"]
 ---
 
 ## What you saw
@@ -18,16 +18,19 @@ The provider name (`anthropic` in the example) varies based on which provider Ma
 
 ## Why it happened
 
-Routing picked a provider that doesn't have a key on file for this agent. Manifest never falls back silently to a different vendor, so the request stops here.
+Routing picked a provider that has no key on file for this agent. Manifest won't silently swap vendors on you, so the request stops here.
 
 ## How to fix it
 
-1. Open the dashboard link in the error message — it goes straight to the agent's **Routing** page.
-2. Add an API key for the named provider, or remove that provider from your tier configuration so routing doesn't pick it.
+1. Open the dashboard link in the error message. It goes straight to the agent's **Routing** page.
+2. Either add an API key for the named provider, or remove that provider from your tier configuration so routing won't pick it again.
 3. Retry the request.
 
 ## Related
 
-- [M101 — No providers configured](/errors/M101)
+- [M101: No providers configured](/errors/M101)
+- [M003: Invalid key format](/errors/M003)
 - [Routing](/routing)
 - [API key providers](/providers/api-key-providers)
+- [Subscription-based providers](/providers/subscription-based-providers)
+- [All error codes](/errors)

--- a/errors/M100.mdx
+++ b/errors/M100.mdx
@@ -1,0 +1,33 @@
+---
+title: "M100 — Provider API key missing"
+sidebarTitle: "M100"
+description: "Manifest routed your request to a provider, but you haven't connected an API key for it yet."
+icon: "plug-zap"
+keywords:
+  ["M100", "provider key", "no API key", "OpenAI key", "Anthropic key", "Manifest routing"]
+---
+
+## What you saw
+
+```text
+[🦚 Manifest M100] No anthropic API key yet. Add one here: https://app.manifest.build/...
+See https://manifest.build/errors/M100
+```
+
+The provider name (`anthropic` in the example) varies based on which provider Manifest selected.
+
+## Why it happened
+
+Routing picked a provider that doesn't have a key on file for this agent. Manifest never falls back silently to a different vendor, so the request stops here.
+
+## How to fix it
+
+1. Open the dashboard link in the error message — it goes straight to the agent's **Routing** page.
+2. Add an API key for the named provider, or remove that provider from your tier configuration so routing doesn't pick it.
+3. Retry the request.
+
+## Related
+
+- [M101 — No providers configured](/errors/M101)
+- [Routing](/routing)
+- [API key providers](/providers/api-key-providers)

--- a/errors/M100.mdx
+++ b/errors/M100.mdx
@@ -11,7 +11,7 @@ keywords:
 
 ```text
 [🦚 Manifest M100] No anthropic API key yet. Add one here: https://app.manifest.build/...
-See https://manifest.build/errors/M100
+See https://manifest.build/docs/errors/M100
 ```
 
 The provider name (`anthropic` in the example) varies based on which provider Manifest selected.

--- a/errors/M101.mdx
+++ b/errors/M101.mdx
@@ -1,0 +1,31 @@
+---
+title: "M101 — No providers configured"
+sidebarTitle: "M101"
+description: "Your agent is authenticated but has no providers connected, so Manifest has nothing to route to."
+icon: "plug-zap"
+keywords:
+  ["M101", "no providers", "first-time setup", "Manifest routing"]
+---
+
+## What you saw
+
+```text
+[🦚 Manifest M101] You're connected, but no providers are set up yet. Add one here: https://app.manifest.build/...
+See https://manifest.build/errors/M101
+```
+
+## Why it happened
+
+This is what you'll usually hit on a fresh agent — your key works, but you haven't added any provider credentials yet (OpenAI, Anthropic, OpenRouter, an Ollama instance, etc.).
+
+## How to fix it
+
+1. Open the dashboard link in the error message.
+2. Connect at least one provider on the **Routing** page. The simplest path is OpenRouter or OpenAI with an API key.
+3. Retry the request.
+
+## Related
+
+- [M100 — Provider API key missing](/errors/M100)
+- [Routing](/routing)
+- [Providers overview](/providers/api-key-providers)

--- a/errors/M101.mdx
+++ b/errors/M101.mdx
@@ -1,10 +1,10 @@
 ---
-title: "M101 — No providers configured"
+title: "M101: No providers configured"
 sidebarTitle: "M101"
-description: "Your agent is authenticated but has no providers connected, so Manifest has nothing to route to."
+description: "Manifest error M101 fires when an authenticated agent has zero providers connected. Common on first run. Fix: connect a provider on the Routing page."
 icon: "plug-zap"
 keywords:
-  ["M101", "no providers", "first-time setup", "Manifest routing"]
+  ["M101", "Manifest M101", "no providers configured", "first-time setup", "empty agent", "Manifest routing", "connect provider", "OpenRouter setup"]
 ---
 
 ## What you saw
@@ -16,16 +16,19 @@ See https://manifest.build/docs/errors/M101
 
 ## Why it happened
 
-This is what you'll usually hit on a fresh agent — your key works, but you haven't added any provider credentials yet (OpenAI, Anthropic, OpenRouter, an Ollama instance, etc.).
+You'll usually see this on a fresh agent. Your key works, but no provider credentials are connected yet (OpenAI, Anthropic, OpenRouter, an Ollama instance, anything).
 
 ## How to fix it
 
 1. Open the dashboard link in the error message.
-2. Connect at least one provider on the **Routing** page. The simplest path is OpenRouter or OpenAI with an API key.
+2. Connect at least one provider on the **Routing** page. The fastest path is OpenRouter or OpenAI with an API key.
 3. Retry the request.
 
 ## Related
 
-- [M100 — Provider API key missing](/errors/M100)
+- [M100: Provider API key missing](/errors/M100)
 - [Routing](/routing)
-- [Providers overview](/providers/api-key-providers)
+- [API key providers](/providers/api-key-providers)
+- [Subscription-based providers](/providers/subscription-based-providers)
+- [Local models (Ollama)](/providers/local-models)
+- [All error codes](/errors)

--- a/errors/M101.mdx
+++ b/errors/M101.mdx
@@ -11,7 +11,7 @@ keywords:
 
 ```text
 [🦚 Manifest M101] You're connected, but no providers are set up yet. Add one here: https://app.manifest.build/...
-See https://manifest.build/errors/M101
+See https://manifest.build/docs/errors/M101
 ```
 
 ## Why it happened

--- a/errors/M200.mdx
+++ b/errors/M200.mdx
@@ -1,10 +1,10 @@
 ---
-title: "M200 — Usage limit exceeded"
+title: "M200: Usage limit exceeded"
 sidebarTitle: "M200"
-description: "Your agent hit a cost or message-count limit you set in the dashboard."
+description: "Manifest error M200 fires when an agent crosses a cost or message-count cap you configured. Returns HTTP 429. Fix: raise the threshold or wait for the period to reset."
 icon: "gauge"
 keywords:
-  ["M200", "usage limit", "cost limit", "spending cap", "Manifest limits"]
+  ["M200", "Manifest M200", "usage limit exceeded", "cost limit", "spending cap", "budget cap", "monthly budget LLM", "Manifest limits", "429 Too Many Requests"]
 ---
 
 ## What you saw
@@ -18,15 +18,18 @@ The metric (cost or messages), used amount, threshold, and period vary based on 
 
 ## Why it happened
 
-You configured a limit on the agent's [Limits](/set-limits) page — for example "$10/day" or "100 messages/hour" — and the current period's usage just crossed it. Manifest blocks every subsequent request until the period resets or you raise the cap.
+You set a limit on the agent's [Limits](/set-limits) page (say, "$10/day" or "100 messages/hour"), and the current period's usage just crossed it. Manifest blocks every following request until the period resets or you raise the cap.
 
 ## How to fix it
 
-1. Open the dashboard link in the error message — it goes straight to the agent's **Limits** page.
-2. Either raise the threshold, change the period, or wait for the period to reset (the message tells you which period).
+1. Open the dashboard link in the error message. It goes straight to the agent's **Limits** page.
+2. Raise the threshold, change the period, or wait for it to reset. The error message tells you which period was hit.
 3. Retry the request.
 
 ## Related
 
 - [Set limits](/set-limits)
-- [M201 — Per-user rate limit](/errors/M201)
+- [M201: Per-user rate limit](/errors/M201)
+- [M202: Per-IP rate limit](/errors/M202)
+- [M203: Concurrency limit](/errors/M203)
+- [All error codes](/errors)

--- a/errors/M200.mdx
+++ b/errors/M200.mdx
@@ -11,7 +11,7 @@ keywords:
 
 ```text
 [🦚 Manifest M200] You hit your cost limit: $12.50 used, $10.00/day allowed. Adjust it here: https://app.manifest.build/...
-See https://manifest.build/errors/M200
+See https://manifest.build/docs/errors/M200
 ```
 
 The metric (cost or messages), used amount, threshold, and period vary based on the rule you tripped.

--- a/errors/M200.mdx
+++ b/errors/M200.mdx
@@ -1,0 +1,32 @@
+---
+title: "M200 — Usage limit exceeded"
+sidebarTitle: "M200"
+description: "Your agent hit a cost or message-count limit you set in the dashboard."
+icon: "gauge"
+keywords:
+  ["M200", "usage limit", "cost limit", "spending cap", "Manifest limits"]
+---
+
+## What you saw
+
+```text
+[🦚 Manifest M200] You hit your cost limit: $12.50 used, $10.00/day allowed. Adjust it here: https://app.manifest.build/...
+See https://manifest.build/errors/M200
+```
+
+The metric (cost or messages), used amount, threshold, and period vary based on the rule you tripped.
+
+## Why it happened
+
+You configured a limit on the agent's [Limits](/set-limits) page — for example "$10/day" or "100 messages/hour" — and the current period's usage just crossed it. Manifest blocks every subsequent request until the period resets or you raise the cap.
+
+## How to fix it
+
+1. Open the dashboard link in the error message — it goes straight to the agent's **Limits** page.
+2. Either raise the threshold, change the period, or wait for the period to reset (the message tells you which period).
+3. Retry the request.
+
+## Related
+
+- [Set limits](/set-limits)
+- [M201 — Per-user rate limit](/errors/M201)

--- a/errors/M201.mdx
+++ b/errors/M201.mdx
@@ -1,10 +1,10 @@
 ---
-title: "M201 — Per-user rate limit exceeded"
+title: "M201: Per-user rate limit exceeded"
 sidebarTitle: "M201"
-description: "Manifest's built-in per-user rate limiter is throttling your agent. Slow down or back off."
+description: "Manifest error M201 fires when one user sends more than 200 requests per minute. Returns HTTP 429. Fix: back off, retry, or raise the cap on self-hosted."
 icon: "timer"
 keywords:
-  ["M201", "rate limit", "429", "throttling", "per-user", "Manifest limits"]
+  ["M201", "Manifest M201", "rate limit", "429 Too Many Requests", "per-user rate limit", "throttling", "exponential backoff", "RATE_MAX_REQUESTS", "Manifest limits"]
 ---
 
 ## What you saw
@@ -14,19 +14,22 @@ keywords:
 See https://manifest.build/docs/errors/M201
 ```
 
-The HTTP status is `429` so SDKs and clients that respect retry-after will back off automatically.
+The HTTP status is `429`, so SDKs that respect retry-after will back off on their own.
 
 ## Why it happened
 
-Manifest enforces a per-user request cap (200 requests per minute by default) to protect the proxy from runaway loops. Your agent crossed that cap inside a 60-second window.
+Manifest caps each user at 200 requests per minute by default. The cap is there mostly to keep runaway loops from melting the proxy. Your agent crossed it inside a 60-second window.
 
 ## How to fix it
 
-1. Add a small delay or use exponential backoff on retry. Most SDKs do this for you when they see a `429`.
-2. If you have parallel workers hitting Manifest, throttle them to share the budget.
-3. If you legitimately need more throughput on a self-hosted install, raise `RATE_MAX_REQUESTS` in `proxy-rate-limiter.ts`.
+1. Add a small delay or exponential backoff on retry. Most SDKs handle this automatically when they see a `429`.
+2. If parallel workers are hitting Manifest, throttle them so they share the budget.
+3. On a self-hosted install where you need more headroom, raise `RATE_MAX_REQUESTS` in `proxy-rate-limiter.ts`.
 
 ## Related
 
-- [M202 — Per-IP rate limit](/errors/M202)
-- [M203 — Concurrency limit](/errors/M203)
+- [M202: Per-IP rate limit](/errors/M202)
+- [M203: Concurrency limit](/errors/M203)
+- [M200: Usage limit exceeded](/errors/M200)
+- [Self-hosted setup](/self-hosted)
+- [All error codes](/errors)

--- a/errors/M201.mdx
+++ b/errors/M201.mdx
@@ -1,0 +1,32 @@
+---
+title: "M201 — Per-user rate limit exceeded"
+sidebarTitle: "M201"
+description: "Manifest's built-in per-user rate limiter is throttling your agent. Slow down or back off."
+icon: "timer"
+keywords:
+  ["M201", "rate limit", "429", "throttling", "per-user", "Manifest limits"]
+---
+
+## What you saw
+
+```text
+[🦚 Manifest M201] Too many requests — wait a few seconds and retry.
+See https://manifest.build/errors/M201
+```
+
+The HTTP status is `429` so SDKs and clients that respect retry-after will back off automatically.
+
+## Why it happened
+
+Manifest enforces a per-user request cap (200 requests per minute by default) to protect the proxy from runaway loops. Your agent crossed that cap inside a 60-second window.
+
+## How to fix it
+
+1. Add a small delay or use exponential backoff on retry. Most SDKs do this for you when they see a `429`.
+2. If you have parallel workers hitting Manifest, throttle them to share the budget.
+3. If you legitimately need more throughput on a self-hosted install, raise `RATE_MAX_REQUESTS` in `proxy-rate-limiter.ts`.
+
+## Related
+
+- [M202 — Per-IP rate limit](/errors/M202)
+- [M203 — Concurrency limit](/errors/M203)

--- a/errors/M201.mdx
+++ b/errors/M201.mdx
@@ -11,7 +11,7 @@ keywords:
 
 ```text
 [🦚 Manifest M201] Too many requests — wait a few seconds and retry.
-See https://manifest.build/errors/M201
+See https://manifest.build/docs/errors/M201
 ```
 
 The HTTP status is `429` so SDKs and clients that respect retry-after will back off automatically.

--- a/errors/M202.mdx
+++ b/errors/M202.mdx
@@ -1,10 +1,10 @@
 ---
-title: "M202 — Per-IP rate limit exceeded"
+title: "M202: Per-IP rate limit exceeded"
 sidebarTitle: "M202"
-description: "Too many requests from a single IP, even across different agent keys."
+description: "Manifest error M202 fires when one IP sends more than 500 requests per minute across all agents. Returns HTTP 429. Fix: stagger workers or raise the IP cap."
 icon: "timer"
 keywords:
-  ["M202", "per-IP rate limit", "429", "shared IP", "Manifest limits"]
+  ["M202", "Manifest M202", "per-IP rate limit", "shared IP", "429 Too Many Requests", "IP_RATE_MAX_REQUESTS", "Manifest limits", "abuse protection"]
 ---
 
 ## What you saw
@@ -16,15 +16,18 @@ See https://manifest.build/docs/errors/M202
 
 ## Why it happened
 
-Manifest also enforces a per-IP cap (500 requests per minute by default) on top of the per-user limit. This catches abuse and dev setups where many agents share one IP. You hit it because the source IP made too many requests across all agents in a 60-second window.
+There's a separate per-IP cap (500 requests per minute by default) sitting on top of the per-user limit. It catches abuse, plus dev setups where lots of agents share one IP. You hit it because that IP fired too many requests across all agents in a 60-second window.
 
 ## How to fix it
 
 1. Back off and retry. The window resets after a minute.
-2. If you're running many agents from one machine in dev, stagger their startup so they don't all hit the proxy at once.
-3. On a self-hosted install with a known trusted source, raise `IP_RATE_MAX_REQUESTS` in `proxy-rate-limiter.ts`.
+2. Running many agents from one machine in dev? Stagger their startup so they don't all hammer the proxy at once.
+3. On a self-hosted install where you trust the source, raise `IP_RATE_MAX_REQUESTS` in `proxy-rate-limiter.ts`.
 
 ## Related
 
-- [M201 — Per-user rate limit](/errors/M201)
-- [M203 — Concurrency limit](/errors/M203)
+- [M201: Per-user rate limit](/errors/M201)
+- [M203: Concurrency limit](/errors/M203)
+- [M200: Usage limit exceeded](/errors/M200)
+- [Self-hosted setup](/self-hosted)
+- [All error codes](/errors)

--- a/errors/M202.mdx
+++ b/errors/M202.mdx
@@ -1,0 +1,30 @@
+---
+title: "M202 — Per-IP rate limit exceeded"
+sidebarTitle: "M202"
+description: "Too many requests from a single IP, even across different agent keys."
+icon: "timer"
+keywords:
+  ["M202", "per-IP rate limit", "429", "shared IP", "Manifest limits"]
+---
+
+## What you saw
+
+```text
+[🦚 Manifest M202] Too many requests from this IP — wait a few seconds and retry.
+See https://manifest.build/errors/M202
+```
+
+## Why it happened
+
+Manifest also enforces a per-IP cap (500 requests per minute by default) on top of the per-user limit. This catches abuse and dev setups where many agents share one IP. You hit it because the source IP made too many requests across all agents in a 60-second window.
+
+## How to fix it
+
+1. Back off and retry. The window resets after a minute.
+2. If you're running many agents from one machine in dev, stagger their startup so they don't all hit the proxy at once.
+3. On a self-hosted install with a known trusted source, raise `IP_RATE_MAX_REQUESTS` in `proxy-rate-limiter.ts`.
+
+## Related
+
+- [M201 — Per-user rate limit](/errors/M201)
+- [M203 — Concurrency limit](/errors/M203)

--- a/errors/M202.mdx
+++ b/errors/M202.mdx
@@ -11,7 +11,7 @@ keywords:
 
 ```text
 [🦚 Manifest M202] Too many requests from this IP — wait a few seconds and retry.
-See https://manifest.build/errors/M202
+See https://manifest.build/docs/errors/M202
 ```
 
 ## Why it happened

--- a/errors/M203.mdx
+++ b/errors/M203.mdx
@@ -1,0 +1,30 @@
+---
+title: "M203 — Concurrency limit exceeded"
+sidebarTitle: "M203"
+description: "Too many requests are in flight at once for this agent."
+icon: "timer"
+keywords:
+  ["M203", "concurrency", "in-flight requests", "429", "Manifest limits"]
+---
+
+## What you saw
+
+```text
+[🦚 Manifest M203] Too many concurrent requests. Give it a moment.
+See https://manifest.build/errors/M203
+```
+
+## Why it happened
+
+Manifest caps how many requests can be in flight per agent at the same time (10 by default). Streaming completions hold a slot until they finish, so a chatty agent that fires off parallel streams can hit this fast.
+
+## How to fix it
+
+1. Wait for in-flight requests to complete, then retry. Most SDKs handle this automatically with backoff on `429`.
+2. Reduce parallelism on the client side — most agents only need 1–3 concurrent calls.
+3. On a self-hosted install, raise `CONCURRENCY_MAX` in `proxy-rate-limiter.ts`.
+
+## Related
+
+- [M201 — Per-user rate limit](/errors/M201)
+- [M202 — Per-IP rate limit](/errors/M202)

--- a/errors/M203.mdx
+++ b/errors/M203.mdx
@@ -1,10 +1,10 @@
 ---
-title: "M203 — Concurrency limit exceeded"
+title: "M203: Concurrency limit exceeded"
 sidebarTitle: "M203"
-description: "Too many requests are in flight at once for this agent."
+description: "Manifest error M203 fires when an agent has more than 10 in-flight requests. Returns HTTP 429. Common with parallel streaming. Fix: reduce parallelism."
 icon: "timer"
 keywords:
-  ["M203", "concurrency", "in-flight requests", "429", "Manifest limits"]
+  ["M203", "Manifest M203", "concurrency limit", "in-flight requests", "429 Too Many Requests", "parallel streams", "CONCURRENCY_MAX", "Manifest limits"]
 ---
 
 ## What you saw
@@ -16,15 +16,18 @@ See https://manifest.build/docs/errors/M203
 
 ## Why it happened
 
-Manifest caps how many requests can be in flight per agent at the same time (10 by default). Streaming completions hold a slot until they finish, so a chatty agent that fires off parallel streams can hit this fast.
+Manifest caps in-flight requests per agent at 10 by default. Streaming completions hold a slot until the stream ends, so an agent that fires off parallel streams can hit this fast.
 
 ## How to fix it
 
-1. Wait for in-flight requests to complete, then retry. Most SDKs handle this automatically with backoff on `429`.
-2. Reduce parallelism on the client side — most agents only need 1–3 concurrent calls.
+1. Let in-flight requests finish, then retry. Most SDKs handle this automatically with backoff on `429`.
+2. Reduce parallelism on the client side. Most agents only need one or two concurrent calls.
 3. On a self-hosted install, raise `CONCURRENCY_MAX` in `proxy-rate-limiter.ts`.
 
 ## Related
 
-- [M201 — Per-user rate limit](/errors/M201)
-- [M202 — Per-IP rate limit](/errors/M202)
+- [M201: Per-user rate limit](/errors/M201)
+- [M202: Per-IP rate limit](/errors/M202)
+- [M200: Usage limit exceeded](/errors/M200)
+- [Self-hosted setup](/self-hosted)
+- [All error codes](/errors)

--- a/errors/M203.mdx
+++ b/errors/M203.mdx
@@ -11,7 +11,7 @@ keywords:
 
 ```text
 [🦚 Manifest M203] Too many concurrent requests. Give it a moment.
-See https://manifest.build/errors/M203
+See https://manifest.build/docs/errors/M203
 ```
 
 ## Why it happened

--- a/errors/M300.mdx
+++ b/errors/M300.mdx
@@ -1,0 +1,38 @@
+---
+title: "M300 — Missing messages array"
+sidebarTitle: "M300"
+description: "Your /v1/chat/completions request body has no messages array."
+icon: "message-square-warning"
+keywords:
+  ["M300", "messages array", "validation", "OpenAI compatible", "Manifest validation"]
+---
+
+## What you saw
+
+```text
+[🦚 Manifest M300] `messages` array is required.
+See https://manifest.build/errors/M300
+```
+
+## Why it happened
+
+The OpenAI-compatible chat completions API requires a `messages` array with at least one entry. Manifest got a body where `messages` is missing, not an array, or empty.
+
+## How to fix it
+
+Send a body shaped like:
+
+```json
+{
+  "model": "auto",
+  "messages": [
+    { "role": "user", "content": "Hello" }
+  ]
+}
+```
+
+If you're using the OpenAI SDK, this happens automatically. If you're hand-crafting the request, double-check the JSON before posting.
+
+## Related
+
+- [M301 — Messages array too long](/errors/M301)

--- a/errors/M300.mdx
+++ b/errors/M300.mdx
@@ -11,7 +11,7 @@ keywords:
 
 ```text
 [🦚 Manifest M300] `messages` array is required.
-See https://manifest.build/errors/M300
+See https://manifest.build/docs/errors/M300
 ```
 
 ## Why it happened

--- a/errors/M300.mdx
+++ b/errors/M300.mdx
@@ -1,10 +1,10 @@
 ---
-title: "M300 — Missing messages array"
+title: "M300: Missing messages array"
 sidebarTitle: "M300"
-description: "Your /v1/chat/completions request body has no messages array."
+description: "Manifest error M300 fires when the /v1/chat/completions body has no messages array (missing, not an array, or empty). Returns HTTP 400."
 icon: "message-square-warning"
 keywords:
-  ["M300", "messages array", "validation", "OpenAI compatible", "Manifest validation"]
+  ["M300", "Manifest M300", "messages array required", "empty messages", "400 Bad Request", "OpenAI compatible API", "chat completions validation", "Manifest validation"]
 ---
 
 ## What you saw
@@ -16,11 +16,11 @@ See https://manifest.build/docs/errors/M300
 
 ## Why it happened
 
-The OpenAI-compatible chat completions API requires a `messages` array with at least one entry. Manifest got a body where `messages` is missing, not an array, or empty.
+The OpenAI-compatible chat completions API requires a `messages` array with at least one entry. Manifest got a body where `messages` was missing, not an array, or empty.
 
 ## How to fix it
 
-Send a body shaped like:
+Send a body shaped like this:
 
 ```json
 {
@@ -31,8 +31,10 @@ Send a body shaped like:
 }
 ```
 
-If you're using the OpenAI SDK, this happens automatically. If you're hand-crafting the request, double-check the JSON before posting.
+The OpenAI SDK handles this for you. If you're hand-rolling the request, eyeball the JSON before posting.
 
 ## Related
 
-- [M301 — Messages array too long](/errors/M301)
+- [M301: Messages array too long](/errors/M301)
+- [API reference](/reference/api)
+- [All error codes](/errors)

--- a/errors/M301.mdx
+++ b/errors/M301.mdx
@@ -1,10 +1,10 @@
 ---
-title: "M301 — Messages array too long"
+title: "M301: Messages array too long"
 sidebarTitle: "M301"
-description: "Your messages array exceeds Manifest's maximum length."
+description: "Manifest error M301 fires when a request has more than 1000 messages. Returns HTTP 400. Fix: trim conversation history or summarize older turns."
 icon: "message-square-warning"
 keywords:
-  ["M301", "messages array", "max messages", "validation", "Manifest validation"]
+  ["M301", "Manifest M301", "messages too long", "max messages 1000", "context window", "400 Bad Request", "agent loop", "Manifest validation"]
 ---
 
 ## What you saw
@@ -16,14 +16,16 @@ See https://manifest.build/docs/errors/M301
 
 ## Why it happened
 
-Manifest caps the number of messages per request at 1000 to keep scoring and tier resolution fast. Long agent loops that never trim their context window can hit this surprisingly quickly.
+Manifest caps each request at 1000 messages so scoring and tier resolution stay fast. Long agent loops that never prune their context window hit this faster than you'd think.
 
 ## How to fix it
 
-1. Trim your conversation history before sending — keep the last N messages plus the system prompt.
-2. Summarize older turns into a single message instead of sending raw history.
-3. If you genuinely need more, split the work across multiple requests.
+1. Trim conversation history before sending. Keep the last N messages plus the system prompt.
+2. Summarize older turns into a single message instead of replaying the raw history.
+3. If you actually need more than 1000, split the work across multiple requests.
 
 ## Related
 
-- [M300 — Missing messages array](/errors/M300)
+- [M300: Missing messages array](/errors/M300)
+- [API reference](/reference/api)
+- [All error codes](/errors)

--- a/errors/M301.mdx
+++ b/errors/M301.mdx
@@ -11,7 +11,7 @@ keywords:
 
 ```text
 [🦚 Manifest M301] `messages` array exceeds maximum length of 1000.
-See https://manifest.build/errors/M301
+See https://manifest.build/docs/errors/M301
 ```
 
 ## Why it happened

--- a/errors/M301.mdx
+++ b/errors/M301.mdx
@@ -1,0 +1,29 @@
+---
+title: "M301 — Messages array too long"
+sidebarTitle: "M301"
+description: "Your messages array exceeds Manifest's maximum length."
+icon: "message-square-warning"
+keywords:
+  ["M301", "messages array", "max messages", "validation", "Manifest validation"]
+---
+
+## What you saw
+
+```text
+[🦚 Manifest M301] `messages` array exceeds maximum length of 1000.
+See https://manifest.build/errors/M301
+```
+
+## Why it happened
+
+Manifest caps the number of messages per request at 1000 to keep scoring and tier resolution fast. Long agent loops that never trim their context window can hit this surprisingly quickly.
+
+## How to fix it
+
+1. Trim your conversation history before sending — keep the last N messages plus the system prompt.
+2. Summarize older turns into a single message instead of sending raw history.
+3. If you genuinely need more, split the work across multiple requests.
+
+## Related
+
+- [M300 — Missing messages array](/errors/M300)

--- a/errors/M500.mdx
+++ b/errors/M500.mdx
@@ -11,7 +11,7 @@ keywords:
 
 ```text
 [🦚 Manifest M500] Something broke on our end. Try again in a moment.
-See https://manifest.build/errors/M500
+See https://manifest.build/docs/errors/M500
 ```
 
 ## Why it happened

--- a/errors/M500.mdx
+++ b/errors/M500.mdx
@@ -1,10 +1,10 @@
 ---
-title: "M500 — Internal server error"
+title: "M500: Internal server error"
 sidebarTitle: "M500"
-description: "Something broke on Manifest's side. The original error was masked to avoid leaking internal details."
+description: "Manifest error M500 is a generic 500 fallback for unhandled errors in the proxy. Usually transient. Fix: retry, then check backend logs on self-hosted."
 icon: "server-crash"
 keywords:
-  ["M500", "internal server error", "5xx", "Manifest server error"]
+  ["M500", "Manifest M500", "internal server error", "500 Internal Server Error", "5xx", "proxy crash", "Manifest server error", "self-hosted debugging"]
 ---
 
 ## What you saw
@@ -16,14 +16,16 @@ See https://manifest.build/docs/errors/M500
 
 ## Why it happened
 
-Manifest hit an unexpected error while handling your request — typically a database hiccup, a downstream provider that returned an unparseable response, or a bug. The original error is logged server-side but masked in the response so we don't leak internals.
+Manifest hit an unexpected error while handling your request. Usually that's a database hiccup, a downstream provider returning something unparseable, or a real bug. The actual stack trace is logged server-side, but masked in the response so we don't leak internals.
 
 ## How to fix it
 
 1. Retry. Most M500s are transient.
-2. If you self-host Manifest, check the backend logs for the actual stack trace.
-3. If it persists, [open an issue](https://github.com/mnfst/manifest/issues) with the timestamp and your agent name. We can correlate it to the server log.
+2. On a self-hosted install, check the backend logs for the real stack trace.
+3. If it sticks around, [open an issue](https://github.com/mnfst/manifest/issues) with the timestamp and your agent name. That's enough for us to correlate it to the server log.
 
 ## Related
 
 - [Self-hosted setup](/self-hosted)
+- [Fallback](/fallback)
+- [All error codes](/errors)

--- a/errors/M500.mdx
+++ b/errors/M500.mdx
@@ -1,0 +1,29 @@
+---
+title: "M500 — Internal server error"
+sidebarTitle: "M500"
+description: "Something broke on Manifest's side. The original error was masked to avoid leaking internal details."
+icon: "server-crash"
+keywords:
+  ["M500", "internal server error", "5xx", "Manifest server error"]
+---
+
+## What you saw
+
+```text
+[🦚 Manifest M500] Something broke on our end. Try again in a moment.
+See https://manifest.build/errors/M500
+```
+
+## Why it happened
+
+Manifest hit an unexpected error while handling your request — typically a database hiccup, a downstream provider that returned an unparseable response, or a bug. The original error is logged server-side but masked in the response so we don't leak internals.
+
+## How to fix it
+
+1. Retry. Most M500s are transient.
+2. If you self-host Manifest, check the backend logs for the actual stack trace.
+3. If it persists, [open an issue](https://github.com/mnfst/manifest/issues) with the timestamp and your agent name. We can correlate it to the server log.
+
+## Related
+
+- [Self-hosted setup](/self-hosted)


### PR DESCRIPTION
### ✨ What changed
- New `errors.mdx` index grouping codes by category (auth, providers, limits, validation, server).
- 14 pages under `errors/` — one per code thrown by the Manifest proxy.
- `docs.json` gains an Errors group under the Documentation tab.

### 💭 Why
Until now, a user hitting `[🦚 Manifest] No anthropic API key yet...` had no canonical fix page to land on. Stable codes plus a docs URL turn every error into a one-click path to a self-serve answer.

### 👤 For users
After deploy, every runtime error message links to `manifest.build/errors/M###`. Pages cover what they saw, why it happened, and how to fix it.

### 📝 Notes
Companion code PR (mnfst/manifest#1771) emits the codes and URLs.