### PR TITLE
docs: document PROVIDER_TIMEOUT_MS env var

### DIFF
--- a/fallback.mdx
+++ b/fallback.mdx
@@ -57,6 +57,12 @@ Fallback models are configured **per tier** in the Manifest dashboard. Each tier
   </Step>
 </Steps>
 
+## Hung providers and the per-attempt timeout
+
+A provider that opens a connection but never returns will eventually trigger a fallback via Manifest's per-attempt timeout (default 180 seconds), which surfaces as a synthetic `504 Gateway Timeout` and triggers the next model in the chain.
+
+If your upstream client (e.g. an agent gateway) has its own timeout that fires at the same time, the client may disconnect first and Manifest will give up before reaching a healthy fallback. On self-hosted installs, lower `PROVIDER_TIMEOUT_MS` strictly below your client's timeout so the fallback chain has room to run within the client's window. See [Self-hosted](/self-hosted) for the env var reference.
+
 ## Response headers
 
 When a fallback succeeds, the response carries `X-Manifest-Fallback-From` (the primary that failed) and `X-Manifest-Fallback-Index` (its position in the chain) on top of the standard routing headers. When the chain is exhausted, `X-Manifest-Fallback-Exhausted: true` is set and the request returns `424`. Full table: [Headers reference](/reference/headers).

--- a/self-hosted.mdx
+++ b/self-hosted.mdx
@@ -267,6 +267,12 @@ docker compose down -v    # destroys all data
 
   Default: 100 requests per 60-second window.
 
+  **LLM proxy**
+
+  | Variable | Default | Description |
+  |----------|---------|-------------|
+  | `PROVIDER_TIMEOUT_MS` | `180000` | Per-attempt timeout (ms) for upstream provider requests. Set strictly below your client's timeout so the [fallback chain](/fallback) has room to run. Slow local models may need this raised. Non-numeric, zero, or negative values fall back to the default. |
+
   **Email alerts (Mailgun)**
 
   | Variable | Description |


### PR DESCRIPTION
## Summary

- Add a `PROVIDER_TIMEOUT_MS` row to the env var reference in `self-hosted.mdx`, in the "Additional environment variables → LLM proxy" subsection.
- Add a new "Hung providers and the per-attempt timeout" section to `fallback.mdx` explaining the timeout-driven fallback path and the rationale for setting `PROVIDER_TIMEOUT_MS` strictly below the upstream client's timeout.

Companion to mnfst/manifest#1607, which makes the previously-hardcoded 180s provider timeout configurable. Slow local models can raise it; fallback-heavy setups should lower it so the chain has room to run within the client's window.

## Test plan

- [ ] Mintlify preview renders the new "LLM proxy" subsection inside the "Additional environment variables" accordion on `/self-hosted`.
- [ ] Mintlify preview renders the new "Hung providers and the per-attempt timeout" section on `/fallback`, between "Configuration" and "Response headers".
- [ ] Cross-link from `fallback.mdx` to `/self-hosted` resolves.