### PR TITLE
docs: front-load API contract on landing and api reference

### DIFF
--- a/introduction.mdx
+++ b/introduction.mdx
@@ -11,6 +11,21 @@ Manifest is a smart model router for agents and AI applications that redirects e
 
 This documentation will help you to get started and use Manifest to use AI efficiently and reduce your inference costs.
 
+## Quick reference
+
+| | |
+|---|---|
+| Cloud base URL | `https://app.manifest.build/v1` |
+| Self-hosted base URL | `http://localhost:2099/v1` |
+| Auth header | `Authorization: Bearer mnfst_<key>` |
+| Get a key | [app.manifest.build](https://app.manifest.build) |
+| Request model | `manifest/auto` (the only accepted value) |
+| OpenAI endpoint | `POST /v1/chat/completions` |
+| Anthropic endpoint | `POST /v1/messages` |
+| Client SDK | None — use the official `openai` or `@anthropic-ai/sdk` packages with `baseURL` set |
+
+The chosen provider model is returned in the response (e.g. `auto→claude-sonnet-4`). Provider-specific names like `gpt-4o-mini` are not accepted as the request model. Full details in the [API reference](/reference/api).
+
 ## Key features
 
 <CardGroup cols={2}>

--- a/reference/api.mdx
+++ b/reference/api.mdx
@@ -23,7 +23,11 @@ Every request requires a Manifest agent key:
 Authorization: Bearer mnfst_YOUR_KEY_HERE
 ```
 
-Generate a key from the dashboard's **Agents** page. Keys always start with `mnfst_`.
+To get one:
+
+1. Sign up at [app.manifest.build](https://app.manifest.build).
+2. Create an agent from the dashboard — its key is shown in the setup modal.
+3. Pass the key as `Authorization: Bearer mnfst_<key>`. Keys always start with `mnfst_`; sending a token without that prefix returns error [M003](/errors/M003).
 
 ## Endpoints
 
@@ -37,7 +41,21 @@ The proxy translates between formats internally, so you can send an OpenAI-shape
 
 ## Chat completions
 
+**Model identifier.** Pass `manifest/auto` — it is the only accepted request model. The chosen provider model is returned in the response (e.g. `auto→claude-sonnet-4`). Do not pass provider-specific names like `gpt-4o-mini` or `claude-sonnet-4` as the request model; they are not accepted.
+
 ```bash
+# Cloud (default):
+curl -X POST https://app.manifest.build/v1/chat/completions \
+  -H "Authorization: Bearer mnfst_YOUR_KEY_HERE" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "manifest/auto",
+    "messages": [
+      {"role": "user", "content": "What is the capital of France?"}
+    ]
+  }'
+
+# Self-hosted (Docker on default port):
 curl -X POST http://localhost:2099/v1/chat/completions \
   -H "Authorization: Bearer mnfst_YOUR_KEY_HERE" \
   -H "Content-Type: application/json" \


### PR DESCRIPTION
## Summary

The cloud base URL, auth header, key prefix, and `manifest/auto` model identifier are spread across multiple pages. An LLM helping a user integrate has to chain through several files just to assemble a working request — and the most common hallucination ("can I pass `gpt-4o-mini` directly?") is never explicitly refuted.

This is a surgical contract-clarity pass on two files. No marketing/positioning changes, no restructure.

- **`introduction.mdx`** — add a **Quick reference** table at the top: cloud base URL, self-hosted base URL, auth header, key acquisition link, the only accepted request model, both endpoint paths, and a note that no client SDK is needed (use `openai` / `@anthropic-ai/sdk` with `baseURL` set).
- **`reference/api.mdx`** —
  - Make the cloud `curl` the primary sample; self-hosted follows. The previous sample only showed `http://localhost:2099`, which silently breaks anyone integrating with the cloud.
  - Add a **Model identifier** callout next to chat completions: `manifest/auto` is the only accepted value; provider-specific names like `gpt-4o-mini` or `claude-sonnet-4` are rejected. This closes the highest-frequency hallucination.
  - Expand the Authentication section into the three explicit steps (sign up → create agent → pass `mnfst_<key>`), with the M003 link surfaced.

## Test plan

- [ ] Mintlify preview renders the Quick reference table on `/introduction` above the feature cards
- [ ] The new cloud `curl` block on `/reference/api` is the first sample under "Chat completions"
- [ ] The M003 link resolves to `/errors/M003`
- [ ] `/llms-full.txt` now contains the Quick reference (it's pulled from `introduction.mdx`)