### PR TITLE
docs: drop deprecated routing, refresh providers and API

### DIFF
--- a/fallback.mdx
+++ b/fallback.mdx
@@ -50,7 +50,7 @@ Fallback models are configured **per tier** in the Manifest dashboard. Each tier
     Navigate to **Routing** in the dashboard.
   </Step>
   <Step title="Select a tier">
-    Click any tier (Simple, Standard, Complex, or Reasoning).
+    Click your Default tier or any custom tier.
   </Step>
   <Step title="Add fallback models">
     Add up to 5 fallback models. Drag to reorder — models are tried from top to bottom.
@@ -72,9 +72,9 @@ When a fallback succeeds, the response carries `X-Manifest-Fallback-From` (the p
 | | Routing | Fallback |
 |---|---|---|
 | **When** | Before the request is sent | After the request fails |
-| **Goal** | Pick the cheapest capable model | Recover from a failure |
-| **Speed** | < 2 ms scoring | Adds one extra round-trip per retry |
-| **Tier** | Assigns a tier | Stays within the same tier |
+| **Goal** | Pick the model for the request | Recover from a failure |
+| **Speed** | In-process, no extra call | Adds one extra round-trip per retry |
+| **Tier** | Picks the tier | Stays within the same tier |
 
 Routing picks the model. Fallback catches it if that model is down.
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -1,35 +1,30 @@
 ---
 title: "Manifest documentation"
 sidebarTitle: "Introduction"
-description: "Open-source LLM router for agents. Sends each query to the cheapest model that can handle it, often saving up to 70% on inference costs."
+description: "Open-source LLM router for agents. Connect your subscriptions, API keys, and local models to any harness through one endpoint, with fallbacks and spend limits."
 icon: "house"
 keywords:
-  ["LLM router", "AI cost optimization", "model routing", "open source", "LLM proxy"]
+  ["LLM router", "AI subscriptions", "model routing", "open source", "LLM gateway"]
 ---
 
-Manifest is a smart model router for agents and AI applications that redirects each query to the right model, saving up to 70% in AI costs.
+Manifest is an open-source LLM router for agents and AI apps. Connect the providers you already use — subscriptions like ChatGPT or Claude, pay-per-token API keys, local models, and custom endpoints — and route every request through one OpenAI- and Anthropic-compatible URL.
 
-This documentation will help you to get started and use Manifest to use AI efficiently and reduce your inference costs.
+You choose which model handles each request. Add fallbacks so a rate limit or a retired model returns a working response instead of an error, cap spending per agent, and see the cost of every call.
 
 ## Key features
 
 <CardGroup cols={2}>
+  <Card title="All your providers" icon="layers" href="/providers/api-key-providers">
+    Connect API keys, subscriptions you already pay for, local models, or any custom endpoint.
+  </Card>
   <Card title="Routing" icon="split" href="/routing">
-    Routing based on complexity, specificity and custom HTTP headers
+    Send each request to your default model, or match a request header to a custom tier.
   </Card>
   <Card title="Fallbacks" icon="life-buoy" href="/fallback">
-    Fallback to different models on failure.
+    Fall back to another model when one fails, so your agent keeps working.
   </Card>
   <Card title="Set limits" icon="shield-alert" href="/set-limits">
     Get email alerts or block requests when spending crosses a threshold.
-  </Card>
-  <Card
-    title="All your providers"
-    icon="layers"
-    href="/providers/api-key-providers"
-  >
-    Plug in every kind of provider: API key, subscription-based, local models or
-    custom.
   </Card>
 </CardGroup>
 

--- a/providers/api-key-providers.mdx
+++ b/providers/api-key-providers.mdx
@@ -11,19 +11,29 @@ Most providers work the standard way: sign up, generate an API key, paste it int
 
 ## Supported providers
 
-| Provider                                        | Where to get a key                                               |
-| ----------------------------------------------- | ---------------------------------------------------------------- |
-| [OpenAI](https://platform.openai.com)           | [platform.openai.com](https://platform.openai.com)               |
-| [Anthropic](https://www.anthropic.com)          | [console.anthropic.com](https://console.anthropic.com)           |
-| [Google](https://ai.google.dev)                 | [ai.google.dev](https://ai.google.dev)                           |
-| [xAI](https://x.ai)                             | [x.ai/api](https://x.ai/api)                                     |
-| [DeepSeek](https://www.deepseek.com)            | [platform.deepseek.com](https://platform.deepseek.com)           |
-| [Mistral](https://mistral.ai)                   | [console.mistral.ai](https://console.mistral.ai)                 |
-| [Qwen (Alibaba)](https://qwen.ai)               | [bailian.console.aliyun.com](https://bailian.console.aliyun.com) |
-| [Moonshot (Kimi)](https://platform.moonshot.cn) | [platform.moonshot.cn](https://platform.moonshot.cn)             |
-| [MiniMax](https://www.minimaxi.com)             | [platform.minimaxi.com](https://platform.minimaxi.com)           |
-| [Z.ai (Zhipu)](https://z.ai)                    | [bigmodel.cn](https://bigmodel.cn)                               |
-| [OpenRouter](https://openrouter.ai)             | [openrouter.ai/keys](https://openrouter.ai/keys)                 |
+| Provider                                          | Where to get a key                                               |
+| ------------------------------------------------- | ---------------------------------------------------------------- |
+| [OpenAI](https://platform.openai.com)             | [platform.openai.com](https://platform.openai.com)               |
+| [Anthropic](https://www.anthropic.com)            | [console.anthropic.com](https://console.anthropic.com)           |
+| [Google](https://ai.google.dev)                   | [ai.google.dev](https://ai.google.dev)                           |
+| [xAI](https://x.ai)                               | [x.ai/api](https://x.ai/api)                                     |
+| [DeepSeek](https://www.deepseek.com)              | [platform.deepseek.com](https://platform.deepseek.com)           |
+| [Mistral](https://mistral.ai)                     | [console.mistral.ai](https://console.mistral.ai)                 |
+| [Alibaba Cloud (Qwen)](https://qwen.ai)           | [bailian.console.aliyun.com](https://bailian.console.aliyun.com) |
+| [Moonshot (Kimi)](https://platform.moonshot.cn)   | [platform.moonshot.cn](https://platform.moonshot.cn)             |
+| [MiniMax](https://www.minimaxi.com)               | [platform.minimaxi.com](https://platform.minimaxi.com)           |
+| [Z.ai (Zhipu)](https://z.ai)                      | [bigmodel.cn](https://bigmodel.cn)                               |
+| [OpenRouter](https://openrouter.ai)               | [openrouter.ai/keys](https://openrouter.ai/keys)                 |
+| [Groq](https://groq.com)                          | [console.groq.com](https://console.groq.com)                     |
+| [Cerebras](https://cerebras.ai)                   | [cloud.cerebras.ai](https://cloud.cerebras.ai)                   |
+| [Fireworks AI](https://fireworks.ai)              | [fireworks.ai](https://fireworks.ai)                             |
+| [NVIDIA NIM](https://build.nvidia.com)            | [build.nvidia.com](https://build.nvidia.com)                     |
+| [AWS Bedrock](https://aws.amazon.com/bedrock)     | [aws.amazon.com/bedrock](https://aws.amazon.com/bedrock)         |
+| [BytePlus](https://www.byteplus.com)              | [byteplus.com](https://www.byteplus.com)                         |
+| [NousResearch](https://nousresearch.com)          | [nousresearch.com](https://nousresearch.com)                     |
+| [OpenCode](https://opencode.ai)                   | [opencode.ai](https://opencode.ai)                               |
+
+Manifest also connects Kilo, Pioneer, Command Code, and Xiaomi MiMo. New providers are added often, so the **Routing** page always shows the current list of tiles.
 
 ## Add a provider
 
@@ -58,3 +68,14 @@ Each provider issues keys with a recognizable prefix. Useful for catching paste 
 | Google     | none      | API key      |
 | Mistral    | none      | API key      |
 | Z.ai       | none      | API key      |
+| Fireworks  | `fw_`     | `fw_...`     |
+| Groq       | `gsk_`    | `gsk_...`    |
+| Pioneer    | `pio_sk_` | `pio_sk_...` |
+| Command Code | `user_` | `user_...`   |
+| Xiaomi MiMo | `sk-`    | `sk-...`     |
+
+Providers not listed here (Cerebras, NVIDIA NIM, AWS Bedrock, BytePlus, NousResearch, OpenCode) issue keys with no fixed prefix.
+
+## Regional providers
+
+Some providers serve more than one region. Alibaba Cloud, AWS Bedrock, and MiniMax let you pick a region when you connect them, and Manifest routes to the matching endpoint.

--- a/providers/custom-providers.mdx
+++ b/providers/custom-providers.mdx
@@ -36,7 +36,7 @@ Common options that ship with one of these formats: [vLLM](https://github.com/vl
     If the endpoint requires authentication, paste an API key. It's sent as `Authorization: Bearer <key>` for OpenAI-format endpoints, or `x-api-key: <key>` for Anthropic-format endpoints.
   </Step>
   <Step title="Probe for models">
-    Manifest calls `GET /v1/models` against your base URL and lists every model the endpoint reports. Pin one to a [complexity tier](/routing#complexity) and you're routed.
+    Manifest calls `GET /v1/models` against your base URL and lists every model the endpoint reports. Pin one to your default or a custom tier and you're routed.
   </Step>
 </Steps>
 

--- a/providers/local-models.mdx
+++ b/providers/local-models.mdx
@@ -51,7 +51,7 @@ All three speak OpenAI-compatible `/v1/chat/completions` and accept any GGUF mod
     Manifest probes `http://localhost:<default-port>/v1/models`. If the probe succeeds, every loaded model appears for routing.
   </Step>
   <Step title="Pin a model to a tier">
-    Open any [complexity tier](/routing#complexity) and pick a local model as the primary. You can mix local and cloud models in the same fallback chain.
+    Open your default or a custom tier and pick a local model as the primary. You can mix local and cloud models in the same fallback chain.
   </Step>
 </Steps>
 
@@ -99,6 +99,6 @@ If you self-host Manifest in Docker, the container can't reach a local server bo
 | **Pricing data**      | Not applicable. Local providers are excluded from pricing sync.|
 
 <Tip>
-  Mix local and cloud in one chain: pin a local model to **simple** for cheap
-  day-to-day calls, fall back to a cloud model when the local server is offline.
+  Mix local and cloud in one chain: set a local model as your default for
+  day-to-day calls, and fall back to a cloud model when the local server is offline.
 </Tip>

--- a/providers/subscription-based-providers.mdx
+++ b/providers/subscription-based-providers.mdx
@@ -1,25 +1,35 @@
 ---
 title: "Subscription-based providers"
 sidebarTitle: "Subscription-based"
-description: "Reuse a paid plan you already have: ChatGPT Plus, Claude Max, GitHub Copilot, GLM Coding Plan, MiniMax, OpenCode Go, or Ollama Cloud."
+description: "Reuse a paid plan you already have: ChatGPT, Claude, Gemini, Grok, GitHub Copilot, GLM Coding Plan, Kimi, Mistral Vibe, and more."
 icon: "credit-card"
 keywords:
-  ["ChatGPT Plus", "Claude Max", "GitHub Copilot", "GLM Coding Plan", "MiniMax Coding Plan", "OpenCode Go", "Ollama Cloud", "OAuth", "device code"]
+  ["ChatGPT Plus", "Claude Max", "GitHub Copilot", "GLM Coding Plan", "Mistral Vibe", "Gemini", "Grok", "Kimi", "OAuth", "device code"]
 ---
 
 If you already pay for ChatGPT Plus, Claude Max, GitHub Copilot, or one of the other plans listed below, Manifest can route through the subscription instead of an API key. Auth is OAuth or a subscription token, depending on the provider.
 
 ## Supported subscriptions
 
-| Provider                                              | Auth flow          |
-| ----------------------------------------------------- | ------------------ |
-| [OpenAI](https://openai.com/chatgpt)                  | OAuth (browser)    |
-| [Anthropic](https://www.anthropic.com/claude)         | OAuth (browser)    |
-| [GitHub Copilot](https://github.com/features/copilot) | Device code        |
-| [MiniMax](https://www.minimaxi.com)                   | OAuth (browser)    |
-| [Z.ai (Zhipu)](https://z.ai)                          | Subscription token |
-| [OpenCode](https://opencode.ai)                       | Subscription token |
-| [Ollama Cloud](https://ollama.com)                    | Account login      |
+| Provider                                              | Plan                 | Auth flow          |
+| ----------------------------------------------------- | -------------------- | ------------------ |
+| [OpenAI](https://openai.com/chatgpt)                  | ChatGPT Plus/Pro     | OAuth (browser)    |
+| [Anthropic](https://www.anthropic.com/claude)         | Claude Pro/Max       | Subscription token |
+| [Google](https://gemini.google.com)                   | Gemini               | OAuth (browser)    |
+| [xAI](https://x.ai)                                   | Grok                 | OAuth (browser)    |
+| [GitHub Copilot](https://github.com/features/copilot) | Copilot              | Device code        |
+| [MiniMax](https://www.minimaxi.com)                   | Coding Plan          | Device code        |
+| [Kiro](https://kiro.dev)                              | Kiro                 | Device code        |
+| [Z.ai (Zhipu)](https://z.ai)                          | GLM Coding Plan      | Subscription token |
+| [Alibaba Cloud (Qwen)](https://qwen.ai)               | Qwen Token Plan      | Subscription token |
+| [Moonshot](https://platform.moonshot.cn)              | Kimi Coding Plan     | Subscription token |
+| [Mistral](https://mistral.ai)                         | Vibe                 | Subscription token |
+| [BytePlus](https://www.byteplus.com)                  | ModelArk Coding Plan | Subscription token |
+| Xiaomi MiMo                                           | Token Plan           | Subscription token |
+| [NousResearch](https://nousresearch.com)              | Subscription         | Subscription token |
+| Command Code                                          | Subscription         | Subscription token |
+| [OpenCode](https://opencode.ai)                       | OpenCode Go          | Subscription token |
+| [Ollama Cloud](https://ollama.com)                    | Ollama Cloud         | Subscription token |
 
 ## Connect a subscription
 
@@ -47,9 +57,10 @@ If you already pay for ChatGPT Plus, Claude Max, GitHub Copilot, or one of the o
     rather than the public OpenAI API. Tokens refresh automatically.
   </Tab>
   <Tab title="Claude">
-    Standard OAuth. Requests carry the `anthropic-beta: oauth-2025-04-20` header
-    so Anthropic recognizes the subscription token. Available models match what
-    your plan grants in claude.ai.
+    Generate a token with the Claude CLI (`claude setup-token`) and paste it into
+    Manifest. Requests carry the `anthropic-beta: oauth-2025-04-20` header so
+    Anthropic recognizes the subscription token. Available models match what your
+    plan grants in claude.ai.
   </Tab>
   <Tab title="GitHub Copilot">
     GitHub's device-code flow. Manifest gives you a short user code, you visit
@@ -59,9 +70,9 @@ If you already pay for ChatGPT Plus, Claude Max, GitHub Copilot, or one of the o
     refreshes for you.
   </Tab>
   <Tab title="MiniMax">
-    OAuth against MiniMax. Requests use the Anthropic protocol via
-    `api.minimax.io/anthropic` (international) or `api.minimaxi.com/anthropic`
-    (China region). The region is picked from the OAuth response.
+    MiniMax's device-code flow. Manifest gives you a short user code to approve,
+    then requests use the Anthropic protocol via `api.minimax.io/anthropic`
+    (international) or `api.minimaxi.com/anthropic` (China).
   </Tab>
   <Tab title="GLM Coding Plan">
     Paste the subscription token issued by Z.ai. Requests route to
@@ -84,4 +95,4 @@ If you already pay for ChatGPT Plus, Claude Max, GitHub Copilot, or one of the o
 
 A common setup: subscription as the primary (predictable monthly cost), API-key provider as the fallback for when you hit the plan limit or want a model the subscription doesn't include.
 
-Pin your subscription model to a [complexity tier](/routing#complexity) and add API-key models to the [fallback list](/fallback#configuration). Manifest handles the switch.
+Pin your subscription model to your default or a custom tier and add API-key models to the [fallback list](/fallback#configuration). Manifest handles the switch.

--- a/reference/api.mdx
+++ b/reference/api.mdx
@@ -3,10 +3,10 @@ title: "API"
 description: "The Manifest proxy speaks both OpenAI and Anthropic. Endpoints, auth, streaming, and error responses."
 icon: "code"
 keywords:
-  ["chat completions", "responses API", "Anthropic messages", "manifest/auto", "streaming", "SSE", "Bearer auth", "424 fallback exhausted"]
+  ["chat completions", "responses API", "Anthropic messages", "auto", "v1/models", "streaming", "SSE", "424 fallback exhausted"]
 ---
 
-Manifest exposes both OpenAI and Anthropic-format endpoints on one proxy. Point your client at the Manifest URL, send `manifest/auto` as the model, and routing picks the real model behind the scenes.
+Manifest exposes both OpenAI and Anthropic-format endpoints on one proxy. Point your client at the Manifest URL, send `auto` as the model, and routing picks the real model behind the scenes.
 
 ## Base URL
 
@@ -32,6 +32,7 @@ Generate a key from the dashboard's **Agents** page. Keys always start with `mnf
 | `POST` | `/v1/chat/completions` | OpenAI | Most clients (OpenAI SDK, LangChain, Vercel AI SDK, custom HTTP) |
 | `POST` | `/v1/responses` | OpenAI Responses | Codex, `*-pro`, `o1-pro`, deep-research models |
 | `POST` | `/v1/messages` | Anthropic | Anthropic SDK, Claude Code, anything that speaks the Messages API |
+| `GET` | `/v1/models` | OpenAI | Listing the models your agent can route to |
 
 The proxy translates between formats internally, so you can send an OpenAI-shaped request and Manifest will reshape it before forwarding to an Anthropic-only model. The reverse works too.
 
@@ -42,7 +43,7 @@ curl -X POST http://localhost:2099/v1/chat/completions \
   -H "Authorization: Bearer mnfst_YOUR_KEY_HERE" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "manifest/auto",
+    "model": "auto",
     "messages": [
       {"role": "user", "content": "What is the capital of France?"}
     ]
@@ -59,13 +60,24 @@ curl -X POST http://localhost:2099/v1/messages \
   -H "Content-Type: application/json" \
   -H "anthropic-version: 2023-06-01" \
   -d '{
-    "model": "manifest/auto",
+    "model": "auto",
     "max_tokens": 1024,
     "messages": [
       {"role": "user", "content": "Hello"}
     ]
   }'
 ```
+
+## Listing models
+
+`GET /v1/models` returns the models your agent can reach, in OpenAI format. The first entry is always `auto` (routing); the rest are the real model IDs from your connected providers.
+
+```bash
+curl http://localhost:2099/v1/models \
+  -H "Authorization: Bearer mnfst_YOUR_KEY_HERE"
+```
+
+Send `auto` to let Manifest route, or send any listed model ID to skip routing and go straight to that provider. See [Routing → Route a specific model](/routing#route-a-specific-model).
 
 ## Streaming
 
@@ -105,4 +117,4 @@ Cloud rate limits are tied to your plan and shown in the dashboard.
 
 ## Response headers
 
-Every response carries [routing headers](/reference/headers) so your client can see which model handled the request, the assigned tier, and confidence, without parsing the response body.
+Every response carries [routing headers](/reference/headers) so your client can see which model and tier handled the request, without parsing the response body.

--- a/reference/environment-variables.mdx
+++ b/reference/environment-variables.mdx
@@ -25,10 +25,22 @@ Manifest reads its configuration from environment variables. In the bundled Dock
 | `BIND_ADDRESS` | `127.0.0.1` | Interface the server binds to. Set to `0.0.0.0` for LAN access |
 | `CORS_ORIGIN` | `http://localhost:3000` | Allowed CORS origin for browser-based dashboard requests |
 | `API_KEY` | — | Internal API key for system endpoints |
+| `MANIFEST_ENCRYPTION_KEY` | `BETTER_AUTH_SECRET` | Key used to encrypt stored provider credentials at rest. Falls back to `BETTER_AUTH_SECRET` when unset |
 | `THROTTLE_TTL` | `60000` | Rate-limit window in milliseconds |
 | `THROTTLE_LIMIT` | `100` | Max requests per window per agent |
-| `DB_POOL_MAX` | `20` | Max PostgreSQL connections in the pool |
+| `DB_POOL_MAX` | `30` | Max PostgreSQL connections in the pool |
 | `SEED_DATA` | `false` | Seed demo data on first boot |
+
+## LLM proxy
+
+How Manifest talks to upstream providers.
+
+| Variable | Default | Description |
+|---|---|---|
+| `PROVIDER_TIMEOUT_MS` | `180000` | Per-attempt timeout (ms) for upstream requests. A hung provider surfaces as a synthetic `504` and triggers the next [fallback](/fallback). Set it strictly below your client's own timeout; slow local models may need it raised |
+| `MANIFEST_MAX_MESSAGES` | `1000` | Max messages Manifest forwards per request. Requests over the cap are rejected with error [M301](/errors/M301) |
+| `STREAM_WARMUP_MS` | `15000` | How long to wait for the first streamed chunk before falling back to the next model |
+| `OLLAMA_HOST` | `http://localhost:11434` | Base URL for a local Ollama server. In Docker, set it to `http://host.docker.internal:11434` |
 
 ## Email
 

--- a/reference/glossary.mdx
+++ b/reference/glossary.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Glossary"
-description: "Definitions for agent, tier, specificity, momentum, fallback chain, manifest/auto, scoring, and confidence."
+description: "Definitions for agent, tier, default and custom routing, direct routing, fallback chain, auto, and provider auth types."
 icon: "book"
 keywords:
-  ["agent", "tier", "specificity", "momentum", "fallback chain", "manifest/auto", "scoring", "confidence", "auth type"]
+  ["agent", "tier", "custom tier", "default routing", "direct routing", "fallback chain", "auto", "provider", "auth type"]
 ---
 
 ## Agent
@@ -15,14 +15,22 @@ A configured client that sends requests through Manifest. Each agent has its own
 The credential category Manifest uses to talk to a provider:
 
 - **`api_key`** — classic per-token API key (most providers)
-- **`subscription`** — OAuth or token tied to a paid plan (ChatGPT Plus, Claude Max, GLM Coding, etc.)
-- **`local`** — no credential, server runs on your machine (Ollama, LM Studio, llama.cpp)
+- **`subscription`** — OAuth or a subscription token tied to a paid plan (ChatGPT Plus, Claude Max, GLM Coding Plan, and others)
+- **`local`** — no credential, the server runs on your machine (Ollama, LM Studio, llama.cpp)
 
 Auth type is recorded on every request and shows up in the dashboard's distribution chart.
 
-## Confidence
+## Auto
 
-A score between `0` and `1` indicating how clearly a request fits its assigned [tier](#tier). Returned in the `X-Manifest-Confidence` response header.
+The model ID you send to opt into routing. When Manifest sees `auto`, it applies your routing rules and picks the real model. Send a real model ID instead to skip routing and target one provider directly (see [Direct routing](#direct-routing)).
+
+## Custom tier
+
+A routing rule matched on a request header. You choose the header key and value on the dashboard and pin the tier to its own model and fallback chain. When a request carries that header, it routes to the tier's model instead of the default. See [Routing → Custom](/routing#custom).
+
+## Direct routing
+
+Sending a real model ID (one that `GET /v1/models` lists) instead of `auto`. Manifest forwards the request straight to that provider and skips tiers and fallbacks. The response carries `X-Manifest-Tier: direct`.
 
 ## Fallback
 
@@ -30,41 +38,21 @@ The retry mechanism that kicks in when the primary model fails. Manifest tries t
 
 ## Fallback chain
 
-The ordered list of models tried for a single tier or specificity, primary first. Up to 5 models. When all of them fail, Manifest returns HTTP `424` with `X-Manifest-Fallback-Exhausted: true`.
-
-## Manifest/auto
-
-The model ID clients send to opt into routing. Any other model ID is forwarded as-is to the matching provider. `manifest/auto` is the only string that triggers tier scoring and model selection.
-
-## Momentum
-
-The carry-over rule that prevents a short follow-up ("yes", "do it") from dropping to a cheaper [tier](#tier). See [Routing → Session momentum](/routing#session-momentum).
+The ordered list of models tried for a single tier, primary first. Up to 5 models. When all of them fail, Manifest returns HTTP `424` with `X-Manifest-Fallback-Exhausted: true`.
 
 ## Provider
 
 An upstream LLM service Manifest can route to. There are four kinds:
 
-- [API key](/providers/api-key-providers) — pay-per-token (OpenAI, Anthropic, Google, …)
-- [Subscription](/providers/subscription-based-providers) — flat-rate plan (ChatGPT Plus, Claude Max, …)
+- [API key](/providers/api-key-providers) — pay-per-token (OpenAI, Anthropic, Google, and more)
+- [Subscription](/providers/subscription-based-providers) — a plan you already pay for (ChatGPT Plus, Claude Max, and more)
 - [Local](/providers/local-models) — runs on your hardware (Ollama, LM Studio, llama.cpp)
 - [Custom](/providers/custom-providers) — any OpenAI- or Anthropic-compatible HTTP endpoint
 
 ## Routing
 
-The scoring + selection process that picks which model handles a request. Two axes drive it: [tier](#tier) (how complex) and [specificity](#specificity) (what kind of task). Both happen in under 2 ms with no external calls.
-
-## Scoring
-
-23 weighted dimensions (14 keyword-based, 5 structural, 4 contextual) that produce a single complexity score. Threshold boundaries map the score to a [tier](#tier). Same pipeline feeds the [specificity](#specificity) detector.
-
-## Specificity
-
-The task category Manifest detects from keyword patterns and tool names. Nine categories: `coding`, `web_browsing`, `data_analysis`, `image_generation`, `video_generation`, `social_media`, `email_management`, `calendar_management`, `trading`. When the match crosses the threshold, you can pin a category-specific model that overrides the per-tier choice. See [Routing → Task-specific](/routing#task-specific).
+The step that decides which model handles a request. Manifest checks your custom tiers first, then sends anything that doesn't match to your default model. It runs in-process with no extra network call. See [Routing](/routing).
 
 ## Tier
 
-The complexity bucket a request falls into: `simple`, `standard`, `complex`, or `reasoning`. Each tier maps to a primary model plus a fallback chain. Tier is the main lever Manifest pulls to balance cost against capability. See [Routing → Complexity](/routing#complexity).
-
-## Tier override
-
-Any signal that forces a minimum tier regardless of the computed score. See [Routing → Tier overrides](/routing#tier-overrides).
+A routing lane with its own model and fallback chain. Every agent has a **Default** tier; you can add **Custom** tiers matched on request headers. See [Routing](/routing).

--- a/reference/headers.mdx
+++ b/reference/headers.mdx
@@ -1,35 +1,35 @@
 ---
 title: "Headers"
-description: "Every x-manifest-* request header and X-Manifest-* response header, with what each one does."
+description: "The request headers Manifest reads and the X-Manifest-* response headers it returns, with what each one does."
 icon: "list"
 keywords:
-  ["X-Manifest-Tier", "X-Manifest-Model", "X-Manifest-Provider", "X-Manifest-Confidence", "X-Manifest-Fallback-From", "x-manifest-specificity", "x-manifest-tier"]
+  ["X-Manifest-Tier", "X-Manifest-Model", "X-Manifest-Provider", "X-Manifest-Reason", "X-Manifest-Fallback-From", "x-session-key", "custom routing header"]
 ---
 
-Manifest reads two request headers to override routing decisions, and returns a set of `X-Manifest-*` response headers so clients can see what happened without parsing the response body.
+Manifest reads a few request headers, and returns a set of `X-Manifest-*` response headers so clients can see what happened without parsing the response body.
 
 ## Request headers
 
-| Header                   | Value                                                                                                                                                                   | Effect                                                                                                            |
-| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `Authorization`          | `Bearer mnfst_<key>`                                                                                                                                                    | **Required.** Authenticates the agent.                                                                            |
-| `Content-Type`           | `application/json`                                                                                                                                                      | **Required.**                                                                                                     |
-| `x-manifest-tier`        | `simple` \| `standard` \| `complex` \| `reasoning`                                                                                                                      | Force the routing tier. Skips scoring.                                                                            |
-| `x-manifest-specificity` | `coding` \| `web_browsing` \| `data_analysis` \| `image_generation` \| `video_generation` \| `social_media` \| `email_management` \| `calendar_management` \| `trading` | Force the [task-specific](/routing#task-specific) routing category. Skips detection. Confidence is `1.0`.        |
-| `anthropic-version`      | `2023-06-01`                                                                                                                                                            | **Required for `/v1/messages`.** Forwarded to the upstream.                                                       |
+| Header                  | Value                | Effect                                                                                                                                              |
+| ----------------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Authorization`         | `Bearer mnfst_<key>` | **Required.** Authenticates the agent.                                                                                                             |
+| `Content-Type`          | `application/json`   | **Required.**                                                                                                                                      |
+| `anthropic-version`     | `2023-06-01`         | **Required for `/v1/messages`.** Forwarded to the upstream.                                                                                        |
+| Your custom tier header | your value           | Routes the request to a [custom tier](/routing#custom). You set the key and value when you create the tier, so the exact header name is up to you. |
+| `x-session-key`         | any string           | Groups requests into a session. Manifest keeps a session on the same upstream where the provider supports it, for sticky routing and prompt caching. |
 
-Header overrides are useful when your agent already knows the task type and doesn't need Manifest to re-detect it.
+The custom tier header is the only one that changes routing: send the header you configured on a tier and the request goes to that tier's model. See [Routing → Custom](/routing#custom).
 
 ## Response headers (every request)
 
-| Header                   | Description                                                    | Example                        |
-| ------------------------ | -------------------------------------------------------------- | ------------------------------ |
-| `X-Manifest-Tier`        | Assigned complexity tier                                       | `complex`                      |
-| `X-Manifest-Model`       | Model that actually served the response                        | `claude-sonnet-4-6`            |
-| `X-Manifest-Provider`    | Upstream provider                                              | `anthropic`                    |
-| `X-Manifest-Confidence`  | Scoring confidence (0–1)                                       | `0.87`                         |
-| `X-Manifest-Reason`      | Why the tier was picked                                        | `keyword: "prove" → reasoning` |
-| `X-Manifest-Specificity` | Detected specificity category (only set when one was assigned) | `coding`                       |
+| Header                       | Description                                                                      | Example         |
+| ---------------------------- | -------------------------------------------------------------------------------- | --------------- |
+| `X-Manifest-Tier`            | The tier that handled the request: `default`, a custom tier's name, or `direct`  | `default`       |
+| `X-Manifest-Model`           | Model that actually served the response                                          | `claude-sonnet-4-6` |
+| `X-Manifest-Provider`        | Upstream provider                                                                | `anthropic`     |
+| `X-Manifest-Reason`          | Why that route was picked: `default`, `header-match`, or `direct`                | `header-match`  |
+| `X-Manifest-Output-Modality` | Output modality of the response                                                  | `text`          |
+| `X-Manifest-Response-Mode`   | Whether the response was streamed or `buffered`                                  | `buffered`      |
 
 ## Response headers (fallback only)
 
@@ -56,12 +56,12 @@ const response = await fetch("http://localhost:2099/v1/chat/completions", {
     "Content-Type": "application/json",
   },
   body: JSON.stringify({
-    model: "manifest/auto",
+    model: "auto",
     messages: [{ role: "user", content: "Hello" }],
   }),
 });
 
-console.log(response.headers.get("x-manifest-tier")); // → "simple"
+console.log(response.headers.get("x-manifest-tier")); // → "default"
 console.log(response.headers.get("x-manifest-model")); // → "gpt-5-mini"
 console.log(response.headers.get("x-manifest-provider")); // → "openai"
 ```

--- a/routing.mdx
+++ b/routing.mdx
@@ -1,97 +1,67 @@
 ---
 title: "Routing"
-description: "How Manifest scores each prompt across 23 dimensions, then sends it to the cheapest model that can handle it."
+description: "Send each request to a default model, match request headers to custom tiers, or pass a real model ID to target one provider directly."
 icon: "split"
 keywords:
-  ["model routing", "complexity tier", "task-specific routing", "LLM router", "x-manifest-tier", "x-manifest-specificity"]
+  ["model routing", "LLM router", "custom routing", "x-manifest-tier", "header routing", "default model", "direct model routing"]
 ---
 
 ## What is routing?
 
-Instead of sending every request to the same model, use Manifest to route your queries to different models and providers.
+Instead of hard-coding one model into every client, you point your client at Manifest and let it pick the model. Send `auto` as the model, and Manifest resolves the real model behind the scenes based on the rules you set on the dashboard **Routing** page.
 
-## The 4 routing types
+## The two routing types
 
 <CardGroup cols={2}>
   <Card title="Default" icon="route" href="#default">
-    Your default model. Switch easily using Manifest UI.
-  </Card>
-  <Card title="Complexity" icon="gauge" href="#complexity">
-    Redirect queries on-the-fly to tiers based on their complexity.
-  </Card>
-  <Card title="Task-specific" icon="target" href="#task-specific">
-    Detect specific tasks queries on-the-fly (coding, trading, image gen…).
+    One model plus up to 5 fallbacks. Every request lands here unless a custom tier matches.
   </Card>
   <Card title="Custom" icon="sliders-horizontal" href="#custom">
-    Isolate requests and assign them to tiers based on their HTTP headers.
+    Match a request header to a tier you define, and route it to its own model.
   </Card>
 </CardGroup>
 
-On-the-fly routing (complexity and task-specific) happens in under 2 ms with zero external calls and extra cost. Default and custom routing are setup beforehand.
+Routing runs in-process. There's no extra network call and no added latency.
 
 ### Default
 
-Every agent has a default model — the one Manifest falls back to when no other routing rule applies. You set it once in the dashboard **Routing** page and can swap it at any time without touching your code. All requests that don't match a complexity tier, specificity, or custom header rule are sent here.
-
-### Complexity
-
-Manifest scores each incoming prompt across 23 dimensions and assigns it to one of four tiers: **simple**, **standard**, **complex**, or **reasoning**. Each tier maps to a different model in the dashboard, so cheap queries go to cheap models and hard queries go to the best ones automatically. Scoring runs in under 2 ms with no external calls.
-
-#### How scoring works
-
-23 dimensions grouped into three categories. The same scoring pipeline feeds both the complexity tier and the specificity detector.
-
-**Keyword-based (14)** — Scans the prompt for patterns like "prove", "write function", "what is", etc.
-
-**Structural (5)** — Analyzes token count, nesting depth, code-to-prose ratio, conditional logic, and constraint density.
-
-**Contextual (4)** — Considers expected output length, repetition requests, tool count, and conversation depth.
-
-Each dimension has a weight. The weighted sum maps to a tier via threshold boundaries. A confidence score (0–1) indicates how clearly the request fits its tier.
-
-#### Session momentum
-
-Manifest remembers the last 5 tier assignments (30-minute TTL).
-
-Short follow-up messages ("yes", "do it") inherit momentum from the conversation, so they don't drop to a cheaper tier unnecessarily.
-
-#### Tier overrides
-
-Some signals force a minimum tier regardless of the score:
-
-| Signal                      | Minimum tier  |
-| --------------------------- | ------------- |
-| Tools detected              | **standard**  |
-| Large context (>50k tokens) | **complex**   |
-| Formal logic keywords       | **reasoning** |
-
-### Task-specific
-
-On top of complexity, Manifest detects **what kind of task** the request is about across nine categories (coding, web browsing, data analysis, image generation, video generation, social media, email, calendar, trading). When a category is detected, the request is routed to the model you've pinned for that category, regardless of the complexity tier. You can toggle each category on or off per agent in the dashboard.
-
-#### Available tiers
-
-| Category             | Covers                                         |
-| -------------------- | ---------------------------------------------- |
-| **Coding**           | Write, debug, and refactor code                |
-| **Web browsing**     | Navigate pages, search, and extract content    |
-| **Data analysis**    | Crunch numbers, run stats, build charts        |
-| **Image generation** | Create and edit images, logos, visuals         |
-| **Video generation** | Produce clips, animations, and edits           |
-| **Social media**     | Draft posts, plan content, track engagement    |
-| **Email**            | Compose, reply, and manage your inbox          |
-| **Calendar**         | Book meetings, check availability, reschedule  |
-| **Trading**          | Analyze markets, place trades, track positions |
-
-#### How detection works
-
-Two signals feed the detector:
-
-1. **Keyword dimensions.** The same trie scan that feeds the complexity score also counts matches in category-specific dimensions (e.g. `codeGeneration` and `technicalTerms` count toward Coding, `webBrowsing` toward Web browsing, `emailManagement` toward Email).
-2. **Tool names.** When a request includes tool definitions, names with known prefixes boost the matching category — `browser_*` / `playwright_*` → Web browsing, `gmail_*` / `outlook_*` → Email, `gcal_*` / `calendly_*` → Calendar, and so on.
-
-If a category crosses the match threshold, it wins. Otherwise no specificity is assigned and the request routes on complexity alone.
+Every agent has a default tier: one model plus up to five fallbacks. You set it on the **Routing** page and can change it anytime without touching your code. Send `auto` as the model, and any request that doesn't match a custom tier goes to your default.
 
 ### Custom
 
-Send an `x-manifest-tier` or `x-manifest-specificity` HTTP header from your client to force a specific tier or category on any request. Manifest uses the header value directly (confidence `1.0`) and skips automatic scoring. This is useful for isolating agent subtasks, A/B testing models, or integrating with orchestration frameworks that classify requests themselves. See the full [request headers reference](/reference/headers) for accepted values.
+Custom tiers route by request header. You create a tier on the dashboard, give it a header key and value, and pin it to a model with its own fallbacks. When an incoming request carries that header, Manifest sends it to that tier's model instead of the default.
+
+The header key is yours to choose (lowercase letters, numbers, and hyphens). A few names are reserved and rejected, including `authorization`, `cookie`, and `x-api-key`. Send the header from your client like any other:
+
+```ts
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "https://app.manifest.build/v1",
+  apiKey: "mnfst_YOUR_KEY",
+  defaultHeaders: { "x-manifest-tier": "batch" }, // your tier's key and value
+});
+
+const response = await client.chat.completions.create({
+  model: "auto",
+  messages: [{ role: "user", content: "Summarize this report." }],
+});
+```
+
+Create as many tiers as you need, each with its own model and parameters. This is handy for isolating an agent's subtasks, A/B testing two models, or letting an orchestration layer decide the tier itself.
+
+### Route a specific model
+
+To skip routing for a single request, send a real model ID instead of `auto`. Manifest forwards it straight to that model's provider, with no tier lookup and no fallbacks. Call [`GET /v1/models`](/reference/api#listing-models) to list the model IDs your agent can reach.
+
+```bash
+curl -X POST https://app.manifest.build/v1/chat/completions \
+  -H "Authorization: Bearer mnfst_YOUR_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "openai/gpt-4o",
+    "messages": [{"role": "user", "content": "Hello"}]
+  }'
+```
+
+The response comes back with `X-Manifest-Tier: direct`, so you can tell a direct call from a routed one. Direct model IDs work on the OpenAI-format endpoints (`/v1/chat/completions` and `/v1/responses`). Requests to the Anthropic `/v1/messages` endpoint always route through your default or custom tiers.

--- a/self-hosted.mdx
+++ b/self-hosted.mdx
@@ -123,7 +123,7 @@ After connecting a provider, send a test request and watch it land in the dashbo
 curl -X POST http://localhost:2099/v1/chat/completions \
   -H "Authorization: Bearer mnfst_YOUR_KEY_HERE" \
   -H "Content-Type: application/json" \
-  -d '{"model": "manifest/auto", "messages": [{"role": "user", "content": "Hello"}]}'
+  -d '{"model": "auto", "messages": [{"role": "user", "content": "Hello"}]}'
 ```
 
 If the response comes back with `That doesn't look like a Manifest key`, you're still using the placeholder — replace `mnfst_YOUR_KEY_HERE` with the real key from the dashboard.
@@ -158,7 +158,7 @@ ports:
 
 ...and in `.env`:
 
-```
+```bash
 BETTER_AUTH_URL=http://localhost:8080
 ```
 
@@ -299,6 +299,12 @@ docker compose down       # Stop services (keeps data)
 docker compose down -v    # Stop and delete all data
 ```
 
+## Data and privacy
+
+Manifest keeps metadata about each request: model, provider, tier, token counts, cost, latency, and a scrubbed error message. It does not keep the message bodies. Prompts and completions are never written to the database, inline image data is stripped out, and error text is scrubbed for secrets before it lands.
+
+Your agents' conversations stay between you and the provider. The usage and cost views in the dashboard are built from that metadata alone.
+
 ## Telemetry
 
 Once a day, each install sends us a small anonymous report. That's how we know whether anyone's actually using the thing, and which providers are popular enough to deserve more work. It's aggregates, never content: no prompts, no messages, no keys, nothing tied to a user. Fifteen fields total.
@@ -312,7 +318,7 @@ Once a day, each install sends us a small anonymous report. That's how we know w
 | `manifest_version` | `5.47.0` | Version adoption across the fleet |
 | `messages_total` | `1284` | Daily activity per install |
 | `messages_by_provider` | `{"anthropic": 700, "openai": 500}` | Provider mix. Anything we don't recognize collapses to `"custom"`, so self-hosted provider names and URLs stay local |
-| `messages_by_tier` | `{"simple": 800, "standard": 400, ...}` | Routing tier usage |
+| `messages_by_tier` | `{"default": 900, "batch": 300, ...}` | Routing tier usage |
 | `messages_by_auth_type` | `{"api_key": 1200, "subscription": 84}` | API key vs. paid-subscription usage |
 | `tokens_input_total` | `1_450_000` | Volume-weighted signal |
 | `tokens_output_total` | `890_000` | Same |
@@ -340,7 +346,7 @@ Tenant IDs, user IDs, emails, API keys, prompts, message contents, model names, 
 
 Put this in your `.env` (or `docker-compose.yml`) and restart the container:
 
-```
+```bash
 MANIFEST_TELEMETRY_DISABLED=1
 ```
 
@@ -350,7 +356,7 @@ The sender checks the flag before doing anything else. No database read, no DNS 
 
 If you'd rather run your own fleet dashboard, point `TELEMETRY_ENDPOINT` at a URL you control:
 
-```
+```bash
 TELEMETRY_ENDPOINT=https://telemetry.mycompany.internal/v1/report
 ```
 

--- a/set-limits.mdx
+++ b/set-limits.mdx
@@ -36,7 +36,7 @@ You can also combine both on a single rule.
 
 When a Hard Limit triggers, the next proxy request returns `429 Too Many Requests` with a message:
 
-```
+```text
 Limit exceeded: cost usage ($X) exceeds $Y per day
 ```
 


### PR DESCRIPTION
### 💭 Why
The docs still centered on complexity and specificity routing, which we remove on September 1, 2026, and the intro sold a "cheapest model, save 70%" pitch tied to it. Provider, env var, and header references had also drifted from the code.

### ✨ What changed
- Rewrote routing around the two current types: default tier and custom header tiers, plus direct model-ID routing.
- Removed complexity and task-specific routing (scoring, momentum, specificity) from every page.
- Fixed the sentinel in all examples: `auto`, not `manifest/auto`. The old value now errors on OpenAI-format endpoints.
- Reframed the intro around connecting subscriptions and providers to any harness.
- Providers: API keys 11 to 24, subscriptions 7 to 17, with corrected auth modes (Anthropic setup-token, MiniMax device code, Ollama token).
- Added 5 proxy env vars and fixed the DB_POOL_MAX default (30).
- Documented GET /v1/models, two always-set response headers, and a data-privacy note (message bodies are never stored).
- Gave every code block a language for syntax highlighting.

### 👤 For users
Docs match the shipped product. Copy-paste examples use `auto` and work on the current proxy.