### PR TITLE
docs: clarify limit error codes

### DIFF
--- a/errors.mdx
+++ b/errors.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Errors"
 description: "Reference for every Manifest proxy error code (M001-M500). What you saw, why it happened, and how to fix it. Covers auth, providers, limits, validation."
 icon: "circle-alert"
 keywords:
-  ["Manifest error codes", "M001", "M100", "M200", "M500", "OpenAI compatible errors", "401 Unauthorized", "429 Too Many Requests", "Bearer token error", "chat completions error", "troubleshooting", "proxy errors"]
+  ["Manifest error codes", "M001", "M100", "M200", "M204", "M500", "OpenAI compatible errors", "401 Unauthorized", "402 Payment Required", "429 Too Many Requests", "Bearer token error", "chat completions error", "troubleshooting", "proxy errors"]
 ---
 
 When Manifest blocks or rejects a request, the response message starts with a code in square brackets:
@@ -37,9 +37,9 @@ Your key is fine, but no provider credentials are wired up. See [Routing](/routi
 | [M100: Provider API key missing](/errors/M100) | Routing picked a provider you haven't connected |
 | [M101: No providers configured](/errors/M101) | Agent has zero providers connected |
 
-## Limits (M200–M203)
+## Limits (M200–M204)
 
-You hit a usage cap or rate limit. They surface as HTTP 429. See [Set limits](/set-limits).
+You hit a usage cap, rate limit, or Free plan request quota. M200-M203 surface as HTTP 429. M204 surfaces as HTTP 402 because it is a billing plan restriction.
 
 | Code | What |
 |------|------|
@@ -47,6 +47,7 @@ You hit a usage cap or rate limit. They surface as HTTP 429. See [Set limits](/s
 | [M201: Per-user rate limit exceeded](/errors/M201) | More than 200 requests/minute from one user |
 | [M202: Per-IP rate limit exceeded](/errors/M202) | More than 500 requests/minute from one IP |
 | [M203: Concurrency limit exceeded](/errors/M203) | More than 10 in-flight requests at once |
+| [M204: Monthly request limit reached](/errors/M204) | Free plan monthly request quota was exhausted |
 
 ## Validation (M300–M301)
 

--- a/errors/M200.mdx
+++ b/errors/M200.mdx
@@ -1,10 +1,10 @@
 ---
 title: "M200: Usage limit exceeded"
 sidebarTitle: "M200"
-description: "Manifest error M200 fires when an agent crosses a cost or message-count cap you configured. Returns HTTP 429. Fix: raise the threshold or wait for the period to reset."
+description: "Manifest error M200 fires when an agent crosses a cost, token, or message-count cap you configured on the Limits page. Returns HTTP 429. Fix: raise the threshold or wait for the period to reset."
 icon: "gauge"
 keywords:
-  ["M200", "Manifest M200", "usage limit exceeded", "cost limit", "spending cap", "budget cap", "monthly budget LLM", "Manifest limits", "429 Too Many Requests"]
+  ["M200", "Manifest M200", "usage limit exceeded", "cost limit", "token limit", "message limit", "spending cap", "budget cap", "monthly budget LLM", "Manifest limits", "429 Too Many Requests"]
 ---
 
 ## What you saw
@@ -14,11 +14,13 @@ keywords:
 See https://manifest.build/docs/errors/M200
 ```
 
-The metric (cost or messages), used amount, threshold, and period vary based on the rule you tripped.
+The metric (cost, tokens, or messages), used amount, threshold, and period vary based on the rule you tripped.
 
 ## Why it happened
 
 You set a limit on the agent's [Limits](/set-limits) page (say, "$10/day" or "100 messages/hour"), and the current period's usage just crossed it. Manifest blocks every following request until the period resets or you raise the cap.
+
+This is different from [M204](/errors/M204), which is the Manifest Cloud Free plan monthly request quota, and different from provider 402 errors such as "insufficient credits" from OpenRouter.
 
 ## How to fix it
 
@@ -32,4 +34,5 @@ You set a limit on the agent's [Limits](/set-limits) page (say, "$10/day" or "10
 - [M201: Per-user rate limit](/errors/M201)
 - [M202: Per-IP rate limit](/errors/M202)
 - [M203: Concurrency limit](/errors/M203)
+- [M204: Monthly request limit reached](/errors/M204)
 - [All error codes](/errors)

--- a/errors/M204.mdx
+++ b/errors/M204.mdx
@@ -1,0 +1,33 @@
+---
+title: "M204: Monthly request limit reached"
+sidebarTitle: "M204"
+description: "Manifest error M204 fires when a Manifest Cloud Free workspace uses all monthly requests. Returns HTTP 402 with PLAN_LIMIT_REQUESTS. Fix: upgrade to Pro or wait for the monthly reset."
+icon: "badge-alert"
+keywords:
+  ["M204", "Manifest M204", "PLAN_LIMIT_REQUESTS", "monthly request limit", "free plan request limit", "Manifest billing", "402 Payment Required", "upgrade to Pro"]
+---
+
+## What you saw
+
+```text
+[🦚 Manifest M204] You've used all 10000 requests included this month on the Free plan. Upgrade to Pro for unlimited requests: https://app.manifest.build/upgrade?reason=requests
+See https://manifest.build/docs/errors/M204
+```
+
+SDK and tool callers receive an HTTP 402 JSON error with `error.code` set to `PLAN_LIMIT_REQUESTS`.
+
+## Why it happened
+
+Your Manifest Cloud workspace reached the Free plan monthly request quota. This is a Manifest plan restriction, not a provider error and not a limit you configured on an agent.
+
+## How to fix it
+
+1. Upgrade to Pro from the dashboard link in the error message.
+2. Or wait for the monthly request quota to reset.
+3. Retry the request after the plan changes or the quota resets.
+
+## Related
+
+- [Upgrade dashboard](https://app.manifest.build/upgrade?reason=requests)
+- [M200: Usage limit exceeded](/errors/M200)
+- [All error codes](/errors)

--- a/reference/api.mdx
+++ b/reference/api.mdx
@@ -102,9 +102,9 @@ The proxy returns a standard JSON error envelope:
 | Status | Meaning |
 |---|---|
 | `401` | Invalid or missing `Authorization` header |
-| `402` | Provider requires payment / quota exceeded on the upstream |
+| `402` | Manifest Free plan quota reached (`error.code = PLAN_LIMIT_REQUESTS`, [M204](/errors/M204)), or provider billing/quota error from the upstream |
 | `424` | Fallback chain exhausted (all configured models failed) |
-| `429` | [Hard limit](/set-limits) hit, or Manifest rate limit (`THROTTLE_LIMIT`) tripped |
+| `429` | [Hard limit](/set-limits) hit ([M200](/errors/M200)), or Manifest rate limit (`THROTTLE_LIMIT`) tripped |
 | `5xx` | Upstream provider error (triggers [fallback](/fallback)) |
 
 Status `424` is the only one that **does not** trigger a fallback. Manifest returns it itself when the chain is exhausted, so re-routing it would loop forever.


### PR DESCRIPTION
### ✨ What changed
- Added M204 for Manifest Free monthly request quota.
- Clarified M200 as user-configured Limits.
- Documented provider 402 as upstream billing or quota.

### 💭 Why
The docs now match the app taxonomy from mnfst/manifest#2456.

### 👤 For users
M200, M204, and provider 402 errors point to different fixes.

### 📝 Notes
App PR: https://github.com/mnfst/manifest/pull/2456