### PR TITLE
docs: add M302 model unavailable error

### DIFF
--- a/errors.mdx
+++ b/errors.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Errors"
 description: "Reference for every Manifest proxy error code (M001-M500). What you saw, why it happened, and how to fix it. Covers auth, providers, limits, validation."
 icon: "circle-alert"
 keywords:
-  ["Manifest error codes", "M001", "M100", "M200", "M204", "M500", "OpenAI compatible errors", "401 Unauthorized", "402 Payment Required", "429 Too Many Requests", "Bearer token error", "chat completions error", "troubleshooting", "proxy errors"]
+  ["Manifest error codes", "M001", "M100", "M200", "M204", "M302", "M500", "OpenAI compatible errors", "401 Unauthorized", "402 Payment Required", "429 Too Many Requests", "Bearer token error", "chat completions error", "model not available", "troubleshooting", "proxy errors"]
 ---
 
 When Manifest blocks or rejects a request, the response message starts with a code in square brackets:
@@ -49,14 +49,15 @@ You hit a usage cap, rate limit, or Free plan request quota. M200-M203 surface a
 | [M203: Concurrency limit exceeded](/errors/M203) | More than 10 in-flight requests at once |
 | [M204: Monthly request limit reached](/errors/M204) | Free plan monthly request quota was exhausted |
 
-## Validation (M300–M301)
+## Request validation and model selection (M300–M302)
 
-The request body is malformed. They surface as HTTP 400.
+M300-M301 mean the request body is malformed and surface as HTTP 400. M302 means the request named a direct model that is not available for this agent; Manifest returns it as a friendly proxy message.
 
 | Code | What |
 |------|------|
 | [M300: Missing messages array](/errors/M300) | Body has no `messages` array, or it's empty |
 | [M301: Messages array too long](/errors/M301) | More than 1000 messages in a single request |
+| [M302: Model not available](/errors/M302) | Explicit model ID is not available for this agent |
 
 ## Server (M500)
 

--- a/errors/M302.mdx
+++ b/errors/M302.mdx
@@ -1,0 +1,43 @@
+---
+title: "M302: Model not available"
+sidebarTitle: "M302"
+description: "Manifest error M302 fires when an explicit model ID is not available for the authenticated agent. Fix: use GET /v1/models or make the provider available for this agent."
+icon: "message-square-warning"
+keywords:
+  ["M302", "Manifest M302", "model not available", "model not found", "GET /v1/models", "direct model routing", "provider not connected", "provider not enabled", "agent-visible models", "Manifest validation"]
+---
+
+## What you saw
+
+```text
+[🦚 Manifest M302] Model "openai/gpt-4o" is not available for this agent. Use GET /v1/models to list available model IDs, or make the provider available for this agent here: https://app.manifest.build/...
+See https://manifest.build/docs/errors/M302
+```
+
+The model name varies based on the `model` value your client sent.
+
+## Why it happened
+
+You sent a concrete model ID instead of `auto` to an OpenAI-format endpoint, but that model is not available to this agent.
+
+This can happen when:
+
+1. The model ID is misspelled or retired.
+2. The provider is not connected yet, or it is connected but not enabled for this agent.
+3. You used a provider-native name when Manifest expects the exact ID returned by `GET /v1/models`.
+4. Manifest refuses the request instead of falling back to automatic routing.
+
+## How to fix it
+
+1. Call `GET /v1/models` with the same Manifest agent key.
+2. Use `auto` to let Manifest route, or copy one of the listed model IDs exactly.
+3. If the model should be available, open the dashboard link in the error and enable or connect that provider for this agent.
+4. Retry the request.
+
+## Related
+
+- [Routing: Route a specific model](/routing#route-a-specific-model)
+- [API reference: Listing models](/reference/api#listing-models)
+- [M300: Missing messages array](/errors/M300)
+- [M301: Messages array too long](/errors/M301)
+- [All error codes](/errors)

--- a/reference/api.mdx
+++ b/reference/api.mdx
@@ -77,7 +77,7 @@ curl http://localhost:2099/v1/models \
   -H "Authorization: Bearer mnfst_YOUR_KEY_HERE"
 ```
 
-Send `auto` to let Manifest route, or send any listed model ID to skip routing and go straight to that provider. See [Routing → Route a specific model](/routing#route-a-specific-model).
+Send `auto` to let Manifest route, or send any listed model ID to skip routing and go straight to that provider. If you send a model ID that is not in this agent-specific list, Manifest returns [M302: Model not available](/errors/M302). See [Routing → Route a specific model](/routing#route-a-specific-model).
 
 ## Streaming
 

--- a/routing.mdx
+++ b/routing.mdx
@@ -65,3 +65,5 @@ curl -X POST https://app.manifest.build/v1/chat/completions \
 ```
 
 The response comes back with `X-Manifest-Tier: direct`, so you can tell a direct call from a routed one. Direct model IDs work on the OpenAI-format endpoints (`/v1/chat/completions` and `/v1/responses`). Requests to the Anthropic `/v1/messages` endpoint always route through your default or custom tiers.
+
+The model list is scoped to the agent key. A model may be missing because its provider is not connected yet, or because the provider exists in your workspace but is not enabled for this agent. If you send an unlisted model ID, Manifest returns [M302: Model not available](/errors/M302). Send `auto` to use routing.


### PR DESCRIPTION
### ✨ What changed
- Added the M302 error page.
- Listed M302 in the error index.
- Noted agent-scoped /v1/models behavior in API and routing docs.

### 💭 Why
Concrete model IDs must be returned by GET /v1/models for the authenticated agent. Unlisted direct model IDs fail with M302; auto is the routing path.

### 👤 For users
The docs now explain how to fix unavailable direct model IDs.