### PR TITLE
docs: stop telling cloud users to set env vars

### DIFF
--- a/autofix.mdx
+++ b/autofix.mdx
@@ -49,22 +49,13 @@ Auto-fix covers non-streaming responses, and streaming responses that fail befor
 
 ## Turning it on
 
-Auto-fix is a single toggle on each agent's **Settings** page in the dashboard.
+Auto-fix is a single toggle on each agent's **Settings** page in the dashboard. It's on by default for new agents. Flip it off on any agent that should never have its requests rewritten.
 
-<Tabs>
-  <Tab title="Cloud">
-    On by default for new agents. Flip the toggle off on any agent that should
-    never have its requests rewritten.
-  </Tab>
-  <Tab title="Self-hosted">
-    Off by default, and it needs a healing service to talk to. Point
-    `AUTOFIX_HEALING_URL` at your [Phoenix](https://github.com/mnfst/phoenix)
-    deployment and set `AUTOFIX_HEALING_API_KEY`. Without a URL configured,
-    Auto-fix stays inert and never touches your traffic.
-  </Tab>
-</Tabs>
+That toggle is the whole setup: there's nothing to install and nothing to configure.
 
-Self-hosted deployments have a few more knobs:
+### Self-hosted
+
+Self-hosting adds one prerequisite. The per-agent toggle works the same way, but it's off by default and Auto-fix needs a healing service to talk to. Point `AUTOFIX_HEALING_URL` at your [Phoenix](https://github.com/mnfst/phoenix) deployment and set `AUTOFIX_HEALING_API_KEY`. Without a URL configured, Auto-fix stays inert and never touches your traffic.
 
 | Variable                      | Default       | Description                                            |
 | ----------------------------- | ------------- | ------------------------------------------------------ |
@@ -73,6 +64,8 @@ Self-hosted deployments have a few more knobs:
 | `AUTOFIX_GLOBAL_ENABLED`      | `true`        | Set `false` to disable Auto-fix for every agent at once |
 | `AUTOFIX_TIMEOUT_MS`          | `10000`       | Per heal call                                          |
 | `AUTOFIX_REPAIRABLE_STATUSES` | `400,404,422` | Which statuses are eligible                            |
+
+These are [environment variables](/reference/environment-variables), so they only apply to a Manifest instance you run yourself.
 
 ## Guardrails
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -32,4 +32,6 @@ You choose which model handles each request. Add fallbacks so a rate limit or a 
 
 Manifest is an open source project that comes in 2 ways: cloud and self-hosted. We recommend the [cloud version](https://app.manifest.build) for newcomers and the [self-hosted version](./self-hosted) for advanced users.
 
-The key difference is that the cloud version runs on our servers, making it easy to setup whereas the self-hosted version must be installed in your local machine of infrastructure.
+The key difference is that the cloud version runs on our servers, whereas the self-hosted version must be installed on your local machine or infrastructure.
+
+On the cloud there is nothing to install and nothing to configure on a server. You sign up, connect your providers, point your harness at the gateway URL, and everything else — routing, limits, [Auto-fix](/autofix), alerts — is a setting in the dashboard. The [environment variables](/reference/environment-variables) throughout these docs apply only to a Manifest instance you run yourself.

--- a/reference/api.mdx
+++ b/reference/api.mdx
@@ -202,7 +202,7 @@ The proxy returns a standard JSON error envelope:
 | `401` | Invalid or missing `Authorization` header |
 | `402` | Manifest Free plan quota reached (`error.code = PLAN_LIMIT_REQUESTS`, [M204](/errors/M204)), or provider billing/quota error from the upstream |
 | `424` | Fallback chain exhausted (all configured models failed) |
-| `429` | [Hard limit](/llm-gateway#hard-limits) hit ([M200](/errors/M200)), or Manifest rate limit (`THROTTLE_LIMIT`) tripped |
+| `429` | [Hard limit](/llm-gateway#hard-limits) hit ([M200](/errors/M200)), or Manifest rate limit tripped |
 | `5xx` | Upstream provider error (triggers [fallback](/llm-gateway#fallback)) |
 
 Status `424` is the only one that **does not** trigger a fallback. Manifest returns it itself when the chain is exhausted, so re-routing it would loop forever.

--- a/reference/environment-variables.mdx
+++ b/reference/environment-variables.mdx
@@ -8,6 +8,12 @@ keywords:
 
 Manifest reads its configuration from environment variables. In the bundled Docker setup these come from `~/manifest/.env`. For `docker run`, pass them with `-e`. For non-Docker installs, export them in the shell before launching the backend.
 
+<Note>
+  This page is for [self-hosted](/self-hosted) instances only. On [Manifest
+  Cloud](https://app.manifest.build) there is no server to configure and no
+  `.env` to edit — everything you can change lives in the dashboard.
+</Note>
+
 ## Core
 
 | Variable | Required | Default | Description |
@@ -98,7 +104,7 @@ Subscription OAuth (ChatGPT, Claude, MiniMax) uses Manifest-side client IDs by d
 |---|---|---|
 | `MANIFEST_TELEMETRY_DISABLED` | unset | Set to `1` to disable [anonymous telemetry](/self-hosted#telemetry) |
 | `TELEMETRY_ENDPOINT` | `https://telemetry.manifest.build/...` | Send reports to your own endpoint |
-| `MANIFEST_PUBLIC_STATS` | `false` | Expose `/api/v1/public/*` aggregate stats without auth (Cloud only) |
+| `MANIFEST_PUBLIC_STATS` | `false` | Set `true` to expose `/api/v1/public/*` aggregate stats without auth |
 
 ## Error monitoring
 


### PR DESCRIPTION
### 💭 Why
On the cloud, Auto-fix is a toggle in each agent's Settings. Nothing else. The page put that behind a Cloud/Self-hosted tab pair with an unscoped `AUTOFIX_*` table right below it, so a cloud reader could reasonably think those variables were theirs to set. Cloud users have no server and no `.env`.

### ✨ What changed
- Auto-fix: the toggle is the lead, env vars moved under a Self-hosted heading.
- Environment variables: note at the top saying the page is self-hosted only.
- Environment variables: dropped the "(Cloud only)" tag on `MANIFEST_PUBLIC_STATS`, which read like a cloud user could set it.
- Introduction: says outright that cloud has nothing to install and nothing to configure on a server.
- API reference: removed the bare `THROTTLE_LIMIT` from the status code table. The Rate limits section below already splits cloud from self-hosted.

### 👤 For users
A cloud user reading the Auto-fix page now sees one toggle and no environment variables.

### 📝 Notes
`mint broken-links` passes. All four pages render locally.