### PR TITLE
docs: group every self-hosting path in one section

### DIFF
--- a/deploy.mdx
+++ b/deploy.mdx
@@ -1,11 +1,13 @@
 ---
-title: "Deployment guides"
-description: "Deploy Manifest on Railway, Render, DigitalOcean, AWS, GCP, Fly.io, Coolify, Easypanel, Heroku, and Koyeb."
+title: "Self-hosting Manifest"
+sidebarTitle: "Overview"
+description: "Every way to run your own Manifest instance: Docker on your machine, a managed platform like Railway, your own AWS or GCP account, or a server panel like Coolify."
 icon: "rocket"
 keywords:
   [
-    "Manifest deployment",
     "self-hosted Manifest",
+    "Manifest deployment",
+    "Docker",
     "Railway",
     "Render",
     "AWS",
@@ -16,7 +18,19 @@ keywords:
   ]
 ---
 
-Use these guides to deploy Manifest with hosted platforms, cloud providers, or self-hosted PaaS tools. For local Docker installs, use the [self-hosted guide](/self-hosted).
+Everything on this page runs the same open-source Manifest image on infrastructure you control, with your own PostgreSQL database. Pick the path that matches where you want it to live. If you'd rather not run anything yourself, [Manifest Cloud](https://app.manifest.build) is the hosted alternative.
+
+## Your own machine
+
+<Card title="Docker" icon="arrow-up-right" href="/self-hosted">
+  The most direct path. One install command, or docker-compose if you want to
+  edit the config first. Also covers upgrades, backups, and bringing your own
+  PostgreSQL.
+</Card>
+
+## Managed platforms
+
+Someone else runs the infrastructure. Usually a one-click template or deploy button.
 
 <CardGroup cols={2}>
   <Card title="Railway" icon="arrow-up-right" href="/deploy/railway">
@@ -31,25 +45,9 @@ Use these guides to deploy Manifest with hosted platforms, cloud providers, or s
     App Platform deploy from the public repository with Manifest and a Dev
     PostgreSQL database.
   </Card>
-  <Card title="AWS" icon="arrow-up-right" href="/deploy/aws">
-    CloudFormation quick-create for ECS Fargate, RDS PostgreSQL, Secrets
-    Manager, and ALB.
-  </Card>
-  <Card title="GCP" icon="arrow-up-right" href="/deploy/gcp">
-    Cloud Shell guided deploy for Cloud Run, Cloud SQL PostgreSQL, and Secret
-    Manager.
-  </Card>
   <Card title="Fly.io" icon="arrow-up-right" href="/deploy/fly">
     CLI-based deploy using the public Docker image, Fly Postgres, and generated
     Manifest secrets.
-  </Card>
-  <Card title="Coolify" icon="arrow-up-right" href="/deploy/coolify">
-    Self-hosted PaaS path using Docker Compose, Coolify magic variables, and
-    PostgreSQL.
-  </Card>
-  <Card title="Easypanel" icon="arrow-up-right" href="/deploy/easypanel">
-    Self-hosted PaaS guide using Easypanel app services, PostgreSQL, and the
-    Manifest Docker image.
   </Card>
   <Card title="Heroku" icon="arrow-up-right" href="/deploy/heroku">
     Deploy-button guide with Heroku Postgres, generated secrets, and one
@@ -61,8 +59,39 @@ Use these guides to deploy Manifest with hosted platforms, cloud providers, or s
   </Card>
 </CardGroup>
 
+## Cloud providers
+
+Your own cloud account, provisioned with the provider's own infrastructure tooling.
+
+<CardGroup cols={2}>
+  <Card title="AWS" icon="arrow-up-right" href="/deploy/aws">
+    CloudFormation quick-create for ECS Fargate, RDS PostgreSQL, Secrets
+    Manager, and ALB.
+  </Card>
+  <Card title="GCP" icon="arrow-up-right" href="/deploy/gcp">
+    Cloud Shell guided deploy for Cloud Run, Cloud SQL PostgreSQL, and Secret
+    Manager.
+  </Card>
+</CardGroup>
+
+## Server panels
+
+A PaaS you run on your own server, so you get deploy buttons on hardware you own.
+
+<CardGroup cols={2}>
+  <Card title="Coolify" icon="arrow-up-right" href="/deploy/coolify">
+    Docker Compose stack using Coolify magic variables and a private PostgreSQL
+    container.
+  </Card>
+  <Card title="Easypanel" icon="arrow-up-right" href="/deploy/easypanel">
+    Easypanel app service using PostgreSQL and the Manifest Docker image.
+  </Card>
+</CardGroup>
+
 ## Before you deploy
 
 Most hosted deployments create paid resources. Review each provider's pricing before leaving test apps running.
 
 For public deployments, make sure `BETTER_AUTH_URL` matches the exact browser URL. If it does not, Better Auth can reject login with an invalid-origin error.
+
+Whichever path you pick, [Environment variables](/reference/environment-variables) is the full configuration list, and [Data and telemetry](/reference/telemetry) covers what your instance stores and what it reports back.

--- a/docs.json
+++ b/docs.json
@@ -89,13 +89,14 @@
           {
             "group": "Getting Started",
             "boost": 3,
-            "pages": ["introduction", "self-hosted"]
+            "pages": ["introduction"]
           },
           {
-            "group": "Deployment",
+            "group": "Self-hosting",
             "boost": 2,
             "pages": [
               "deploy",
+              "self-hosted",
               {
                 "group": "Managed platforms",
                 "icon": "cloud",
@@ -116,7 +117,7 @@
                 "pages": ["deploy/aws", "deploy/gcp"]
               },
               {
-                "group": "Self-hosted panels",
+                "group": "Server panels",
                 "icon": "panel-top",
                 "expanded": false,
                 "pages": ["deploy/coolify", "deploy/easypanel"]
@@ -144,8 +145,9 @@
               "reference/api",
               "reference/headers",
               "reference/environment-variables",
-              "reference/glossary",
-              "errors"
+              "reference/telemetry",
+              "errors",
+              "reference/glossary"
             ]
           }
         ]
@@ -202,6 +204,14 @@
     {
       "source": "/docker",
       "destination": "/self-hosted"
+    },
+    {
+      "source": "/telemetry",
+      "destination": "/reference/telemetry"
+    },
+    {
+      "source": "/privacy",
+      "destination": "/reference/telemetry"
     },
     {
       "source": "/cloud-vs-local",

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -30,8 +30,19 @@ You choose which model handles each request. Add fallbacks so a rate limit or a 
 
 ## Cloud or self-hosted?
 
-Manifest is an open source project that comes in 2 ways: cloud and self-hosted. We recommend the [cloud version](https://app.manifest.build) for newcomers and the [self-hosted version](./self-hosted) for advanced users.
+Manifest is open source and runs two ways. Both speak the same API, so pointing a client at one or the other is a URL change.
 
-The key difference is that the cloud version runs on our servers, whereas the self-hosted version must be installed on your local machine or infrastructure.
+<CardGroup cols={2}>
+  <Card title="Manifest Cloud" icon="cloud" href="https://app.manifest.build">
+    Runs on our servers. Sign up, connect a provider, and you're routing.
+    Recommended if you're starting out.
+  </Card>
+  <Card title="Self-hosting" icon="server" href="/deploy">
+    Runs on infrastructure you control: Docker on your own machine, a managed
+    platform like Railway, your AWS or GCP account, or a server panel.
+  </Card>
+</CardGroup>
 
 On the cloud there is nothing to install and nothing to configure on a server. You sign up, connect your providers, point your harness at the gateway URL, and everything else — routing, limits, [Auto-fix](/autofix), alerts — is a setting in the dashboard. The [environment variables](/reference/environment-variables) throughout these docs apply only to a Manifest instance you run yourself.
+
+Cloud is also subject to [plan limits](/errors/M204) and can't reach [local models](/providers/local-models) running on your machine. A self-hosted instance has neither restriction.

--- a/observability.mdx
+++ b/observability.mdx
@@ -113,7 +113,7 @@ Self-hosted installs swap the base URL for their own host.
 
 ## Anonymous telemetry
 
-Separately from your dashboard, each self-hosted install sends a small daily report so the project can see version adoption and which providers deserve attention. It's aggregates only, never prompts or content, and one environment variable turns it off. Full field list and opt-out: [Self-hosted → Telemetry](/self-hosted#telemetry).
+Separately from your dashboard, each self-hosted install sends a small daily report so the project can see version adoption and which providers deserve attention. It's aggregates only, never prompts or content, and one environment variable turns it off. Full field list and opt-out: [Data and telemetry](/reference/telemetry).
 
 ## Related
 

--- a/reference/environment-variables.mdx
+++ b/reference/environment-variables.mdx
@@ -102,7 +102,7 @@ Subscription OAuth (ChatGPT, Claude, MiniMax) uses Manifest-side client IDs by d
 
 | Variable | Default | Description |
 |---|---|---|
-| `MANIFEST_TELEMETRY_DISABLED` | unset | Set to `1` to disable [anonymous telemetry](/self-hosted#telemetry) |
+| `MANIFEST_TELEMETRY_DISABLED` | unset | Set to `1` to disable [anonymous telemetry](/reference/telemetry) |
 | `TELEMETRY_ENDPOINT` | `https://telemetry.manifest.build/...` | Send reports to your own endpoint |
 | `MANIFEST_PUBLIC_STATS` | `false` | Set `true` to expose `/api/v1/public/*` aggregate stats without auth |
 

--- a/reference/telemetry.mdx
+++ b/reference/telemetry.mdx
@@ -1,0 +1,82 @@
+---
+title: "Data and telemetry"
+sidebarTitle: "Data & telemetry"
+description: "What Manifest stores about your requests, what it never stores, and the anonymous daily report each self-hosted install sends. Includes the full field list and how to opt out."
+icon: "shield"
+keywords:
+  ["data privacy", "prompt storage", "anonymous telemetry", "MANIFEST_TELEMETRY_DISABLED", "TELEMETRY_ENDPOINT", "install_id", "opt out", "self-hosted telemetry"]
+---
+
+Two separate things happen to data as requests flow through Manifest: what your own instance records for the dashboard, and what a self-hosted install reports back to the project. This page covers both.
+
+## What Manifest stores
+
+Manifest keeps metadata about each request: model, provider, tier, token counts, cost, latency, and a scrubbed error message. It does not keep the message bodies. Prompts and completions are never written to the database, inline image data is stripped out, and error text is scrubbed for secrets before it lands.
+
+Your agents' conversations stay between you and the provider. The usage and cost views in the dashboard are built from that metadata alone. See [Observability](/observability) for what that record looks like in practice.
+
+## Anonymous telemetry
+
+Once a day, each self-hosted install sends us a small anonymous report. That's how we know whether anyone's actually using the thing, and which providers are popular enough to deserve more work. It's aggregates, never content: no prompts, no messages, no keys, nothing tied to a user. Fifteen fields total.
+
+<Note>
+  This section applies to self-hosted installs only. Manifest Cloud has no
+  separate telemetry report — your usage is already in your own dashboard.
+</Note>
+
+### What gets sent
+
+| Field | Example | Purpose |
+|-------|---------|---------|
+| `schema_version` | `1` | So the shape can grow without breaking old clients. Stays `1` for additive changes; bumps on breaking ones |
+| `install_id` | random UUIDv4 | Count distinct installs. Generated once on first boot, persisted, never rotated |
+| `manifest_version` | `5.47.0` | Version adoption across the fleet |
+| `messages_total` | `1284` | Daily activity per install |
+| `messages_by_provider` | `{"anthropic": 700, "openai": 500}` | Provider mix. Anything we don't recognize collapses to `"custom"`, so self-hosted provider names and URLs stay local |
+| `messages_by_tier` | `{"default": 900, "batch": 300, ...}` | Routing tier usage |
+| `messages_by_auth_type` | `{"api_key": 1200, "subscription": 84}` | API key vs. paid-subscription usage |
+| `tokens_input_total` | `1_450_000` | Volume-weighted signal |
+| `tokens_output_total` | `890_000` | Same |
+| `cost_usd_total` <sup>†</sup> | `47.83` | Sum of `cost_usd` Manifest computed at routing time, rounded to cents. Lets us see real dollar throughput instead of guessing from token counts. `0` for Ollama-only / free-API installs |
+| `cost_usd_by_provider` <sup>†</sup> | `{"anthropic": 30.50, "openai": 17.33}` | Per-provider split of `cost_usd_total`, rounded to cents. Same `"custom"` collapse rule as `messages_by_provider` — admin-configured BYOK pricing is never keyed by the raw provider name |
+| `agents_total` | `4` | Configuration scale |
+| `agents_by_platform` | `{"openclaw": 3, "hermes": 1}` | Which agent clients people use |
+| `platform` | `linux` / `darwin` / `windows` | OS distribution |
+| `arch` | `x64` / `arm64` | Architecture distribution |
+
+<sup>†</sup> *Optional. Installs running older Manifest versions omit these fields; receivers should feature-detect on presence rather than on `schema_version`. Cost values are derived from the same `input_tokens` / `output_tokens` we already ship, multiplied by Manifest's per-model pricing table — no new data leaves the box, just a rolled-up dollar figure for what's already disclosed.*
+
+### Never sent
+
+Tenant IDs, user IDs, emails, API keys, prompts, message contents, model names, custom provider URLs, OAuth client IDs, hostnames, raw IPs. The ingest takes a SHA-256 of your IP and throws the original away; we keep the hash so we can rate-limit bad actors without knowing where they actually live.
+
+### When
+
+- Once every 24 hours, per install.
+- The first report is delayed by a random 0–24h offset, so a fleet of containers rebooted together doesn't all hit the endpoint at the same minute.
+- Off by default when `NODE_ENV != production`. Dev machines are never going to accidentally send.
+- If the endpoint is down, we log it and try again on the next hourly tick. Your proxy keeps serving requests — the sender never gets in the way.
+
+### Turning it off
+
+Put this in your `.env` (or `docker-compose.yml`) and restart the container:
+
+```bash
+MANIFEST_TELEMETRY_DISABLED=1
+```
+
+The sender checks the flag before doing anything else. No database read, no DNS lookup, no request leaves the box.
+
+### Sending it somewhere else
+
+If you'd rather run your own fleet dashboard, point `TELEMETRY_ENDPOINT` at a URL you control:
+
+```bash
+TELEMETRY_ENDPOINT=https://telemetry.mycompany.internal/v1/report
+```
+
+## Related
+
+- [Observability](/observability) — what the recorded metadata gets you
+- [Environment variables](/reference/environment-variables) — `MANIFEST_TELEMETRY_DISABLED` and `TELEMETRY_ENDPOINT` in context
+- [Self-hosting with Docker](/self-hosted) — where to put these variables

--- a/self-hosted.mdx
+++ b/self-hosted.mdx
@@ -1,12 +1,15 @@
 ---
-title: "Self-hosted"
-description: "Run Manifest on your own machine with Docker. Covers the quick installer, docker-compose, bringing your own PostgreSQL, signed images, and telemetry opt-out."
+title: "Self-hosting with Docker"
+sidebarTitle: "Docker"
+description: "Run Manifest on your own machine with Docker. Covers the quick installer, docker-compose, bringing your own PostgreSQL, signed images, upgrades, and backups."
 icon: "docker"
 keywords:
-  ["self-hosted LLM router", "Docker", "docker-compose", "PostgreSQL", "BETTER_AUTH_SECRET", "telemetry"]
+  ["self-hosted LLM router", "Docker", "docker-compose", "PostgreSQL", "BETTER_AUTH_SECRET", "docker run", "upgrade", "backup"]
 ---
 
 Run the full Manifest stack on your own machine. No Node.js required, just Docker.
+
+To run Manifest somewhere other than your own machine, see the [other self-hosting paths](/deploy).
 
 All three paths end in the same place: a running stack at [http://localhost:2099](http://localhost:2099) where you sign up. The first account you create becomes the admin. No demo credentials are pre-seeded.
 
@@ -262,64 +265,13 @@ docker compose down -v    # Stop and delete all data
 
 ## Data and privacy
 
-Manifest keeps metadata about each request: model, provider, tier, token counts, cost, latency, and a scrubbed error message. It does not keep the message bodies. Prompts and completions are never written to the database, inline image data is stripped out, and error text is scrubbed for secrets before it lands.
-
-Your agents' conversations stay between you and the provider. The usage and cost views in the dashboard are built from that metadata alone.
+Manifest keeps metadata about each request — model, provider, tier, token counts, cost, latency — and never the message bodies. Prompts and completions are not written to the database.
 
 ## Telemetry
 
-Once a day, each install sends us a small anonymous report. That's how we know whether anyone's actually using the thing, and which providers are popular enough to deserve more work. It's aggregates, never content: no prompts, no messages, no keys, nothing tied to a user. Fifteen fields total.
+Once a day, each install sends an anonymous aggregate report: version, provider mix, token and cost totals. Never prompts, keys, or anything tied to a user. Set `MANIFEST_TELEMETRY_DISABLED=1` in your `.env` to turn it off.
 
-### What gets sent
-
-| Field | Example | Purpose |
-|-------|---------|---------|
-| `schema_version` | `1` | So the shape can grow without breaking old clients. Stays `1` for additive changes; bumps on breaking ones |
-| `install_id` | random UUIDv4 | Count distinct installs. Generated once on first boot, persisted, never rotated |
-| `manifest_version` | `5.47.0` | Version adoption across the fleet |
-| `messages_total` | `1284` | Daily activity per install |
-| `messages_by_provider` | `{"anthropic": 700, "openai": 500}` | Provider mix. Anything we don't recognize collapses to `"custom"`, so self-hosted provider names and URLs stay local |
-| `messages_by_tier` | `{"default": 900, "batch": 300, ...}` | Routing tier usage |
-| `messages_by_auth_type` | `{"api_key": 1200, "subscription": 84}` | API key vs. paid-subscription usage |
-| `tokens_input_total` | `1_450_000` | Volume-weighted signal |
-| `tokens_output_total` | `890_000` | Same |
-| `cost_usd_total` <sup>†</sup> | `47.83` | Sum of `cost_usd` Manifest computed at routing time, rounded to cents. Lets us see real dollar throughput instead of guessing from token counts. `0` for Ollama-only / free-API installs |
-| `cost_usd_by_provider` <sup>†</sup> | `{"anthropic": 30.50, "openai": 17.33}` | Per-provider split of `cost_usd_total`, rounded to cents. Same `"custom"` collapse rule as `messages_by_provider` — admin-configured BYOK pricing is never keyed by the raw provider name |
-| `agents_total` | `4` | Configuration scale |
-| `agents_by_platform` | `{"openclaw": 3, "hermes": 1}` | Which agent clients people use |
-| `platform` | `linux` / `darwin` / `windows` | OS distribution |
-| `arch` | `x64` / `arm64` | Architecture distribution |
-
-<sup>†</sup> *Optional. Installs running older Manifest versions omit these fields; receivers should feature-detect on presence rather than on `schema_version`. Cost values are derived from the same `input_tokens` / `output_tokens` we already ship, multiplied by Manifest's per-model pricing table — no new data leaves the box, just a rolled-up dollar figure for what's already disclosed.*
-
-### Never sent
-
-Tenant IDs, user IDs, emails, API keys, prompts, message contents, model names, custom provider URLs, OAuth client IDs, hostnames, raw IPs. The ingest takes a SHA-256 of your IP and throws the original away; we keep the hash so we can rate-limit bad actors without knowing where they actually live.
-
-### When
-
-- Once every 24 hours, per install.
-- The first report is delayed by a random 0–24h offset, so a fleet of containers rebooted together doesn't all hit the endpoint at the same minute.
-- Off by default when `NODE_ENV != production`. Dev machines are never going to accidentally send.
-- If the endpoint is down, we log it and try again on the next hourly tick. Your proxy keeps serving requests — the sender never gets in the way.
-
-### Turning it off
-
-Put this in your `.env` (or `docker-compose.yml`) and restart the container:
-
-```bash
-MANIFEST_TELEMETRY_DISABLED=1
-```
-
-The sender checks the flag before doing anything else. No database read, no DNS lookup, no request leaves the box.
-
-### Sending it somewhere else
-
-If you'd rather run your own fleet dashboard, point `TELEMETRY_ENDPOINT` at a URL you control:
-
-```bash
-TELEMETRY_ENDPOINT=https://telemetry.mycompany.internal/v1/report
-```
+Full field list, what's never sent, and how to point it at your own endpoint: [Data and telemetry](/reference/telemetry).
 
 ## Docker Hub
 


### PR DESCRIPTION
### 💭 Why

Docker was the one self-hosting path missing from the deployment sidebar. Someone browsing "Deployment" for how to run Manifest never saw it, even though it's the most direct option.

The group names also didn't describe what was under them. "Getting Started" held a Docker install guide. Everything under "Deployment" was self-hosting anyway, so "Self-hosted panels" was redundant with its own parent.

### ✨ What changed

- "Deployment" renamed to "Self-hosting". The Docker page now sits inside it.
- "Self-hosted panels" renamed to "Server panels".
- `/deploy` overview reorganized into the same four groups as the sidebar, Docker first.
- Data/privacy and telemetry split out of the Docker guide into `/reference/telemetry`. That page was 327 lines and mixed install steps with a 15-field telemetry spec that applies to Cloud too.
- Introduction's cloud vs self-hosted section rewritten as cards. Fixes a typo ("in your local machine of infrastructure").

### 👤 For users

Every way to run your own instance is now in one sidebar group. No URLs changed, so existing links and the error-message deep links still resolve.

### 📝 Notes

`mint broken-links` passes. Added `/telemetry` and `/privacy` redirects to the new reference page.

Not included, worth a follow-up: there is no quickstart for Cloud users. The docs go from Introduction straight to self-hosting, so "Getting Started" is now a single page.