### PR TITLE
docs: fix dead links and wrong values in self-hosting guide

### DIFF
--- a/introduction.mdx
+++ b/introduction.mdx
@@ -32,4 +32,4 @@ You choose which model handles each request. Add fallbacks so a rate limit or a 
 
 Manifest is an open source project that comes in 2 ways: cloud and self-hosted. We recommend the [cloud version](https://app.manifest.build) for newcomers and the [self-hosted version](./self-hosted) for advanced users.
 
-The key difference is that the cloud version runs on our servers, making it easy to setup whereas the self-hosted version must be installed in your local machine of infrastructure.
+The key difference is that the cloud version runs on our servers, making it easy to setup whereas the self-hosted version must be installed on your own machine or infrastructure.

--- a/reference/environment-variables.mdx
+++ b/reference/environment-variables.mdx
@@ -15,17 +15,18 @@ Manifest reads its configuration from environment variables. In the bundled Dock
 | `DATABASE_URL` | Yes | — | PostgreSQL connection string. Format: `postgresql://user:pass@host:5432/dbname` |
 | `BETTER_AUTH_SECRET` | Yes | — | Session signing secret. Min 32 chars. Generate with `openssl rand -hex 32` |
 | `BETTER_AUTH_URL` | No | `http://localhost:2099` | Public URL the dashboard is reachable on. Must match the browser URL |
-| `PORT` | No | `2099` | Internal server port |
-| `NODE_ENV` | No | `production` | Node environment. Telemetry is disabled when this isn't `production` |
+| `PORT` | No | `2099` | Dashboard port. Under the bundled compose file this sets both the published host port and the internal listener, and `BETTER_AUTH_URL` follows it |
+| `NODE_ENV` | No | `production` | Node environment. Telemetry is disabled when this isn't `production`. Fixed to `production` by the bundled compose file — the image is a production artifact |
 
 ## Network & security
 
 | Variable | Default | Description |
 |---|---|---|
-| `BIND_ADDRESS` | `127.0.0.1` | Interface the server binds to. Set to `0.0.0.0` for LAN access |
-| `CORS_ORIGIN` | `http://localhost:3000` | Allowed CORS origin for browser-based dashboard requests |
+| `BIND_ADDRESS` | `127.0.0.1` | Interface the server binds to. Set to `0.0.0.0` for LAN access. The Docker image already sets `0.0.0.0`; restrict a container with the compose `ports` line instead |
+| `CORS_ORIGIN` | `http://localhost:3000` | Allowed CORS origin for browser-based dashboard requests. Development only — production uses the built-in allowlist plus `WINGMAN_CORS_ORIGINS` |
 | `API_KEY` | — | Internal API key for system endpoints |
-| `MANIFEST_ENCRYPTION_KEY` | `BETTER_AUTH_SECRET` | Key used to encrypt stored provider credentials at rest. Falls back to `BETTER_AUTH_SECRET` when unset |
+| `MANIFEST_ENCRYPTION_KEY` | `BETTER_AUTH_SECRET` | Key used to encrypt stored provider credentials at rest. Falls back to `BETTER_AUTH_SECRET` when unset — set a separate 32+ char value so a session-cookie leak doesn't also decrypt every stored provider key. Set it before first boot |
+| `MANIFEST_DISABLE_HSTS` | — | Set `1` to silence the boot warning about HSTS being unavailable on a plain-HTTP deployment. Prefer an `https://` `BETTER_AUTH_URL` anywhere reachable from the internet |
 | `WINGMAN_CORS_ORIGINS` | — | Extra browser origins allowed to call the gateway, comma-separated. The hosted gateway tester at `wingman.manifest.build` is always allowed |
 | `THROTTLE_TTL` | `60000` | Rate-limit window in milliseconds |
 | `THROTTLE_LIMIT` | `100` | Max requests per window per agent |
@@ -38,7 +39,7 @@ Manifest reads its configuration from environment variables. In the bundled Dock
 | `AUTH_DB_POOL_MAX` | `10` | Separate pool used by Better Auth. Counted on top of `DB_POOL_MAX` when sizing your server's `max_connections` |
 | `RUN_MIGRATIONS_ON_BOOT` | `true` | Run pending migrations at startup. Set `false` on multi-replica deploys so only one instance migrates |
 | `DB_TUNE_SESSION` | `true` | Apply Manifest's planner defaults at boot. Set `false` on managed Postgres where your role can't `ALTER ROLE` itself |
-| `SEED_DATA` | `false` | Seed demo data on first boot |
+| `SEED_DATA` | `false` | Seed demo data on first boot. Development only — the seeder refuses to run under `NODE_ENV=production`, so it has no effect on a Docker self-host. Use the first-run setup wizard to create your admin account |
 
 ## LLM proxy
 

--- a/self-hosted.mdx
+++ b/self-hosted.mdx
@@ -34,7 +34,7 @@ All three paths end in the same place: a running stack at [http://localhost:2099
 
     Useful flags: `--dir <path>` to install elsewhere, `--dry-run` to preview, `--yes` to skip the confirmation prompt.
 
-    When the installer finishes, open [http://localhost:2099](http://localhost:2099) and sign up for an account. Then head to the [Routing](http://localhost:2099/routing) page to add an LLM provider (OpenAI, Anthropic, Gemini, etc.) with your API key.
+    When the installer finishes, open [http://localhost:2099](http://localhost:2099) and sign up for an account. Then connect a provider and send your first request — see [First request](#first-request).
   </Tab>
   <Tab title="Docker Compose">
     Same underlying flow as the install script, but you drive it yourself so you can edit the config before booting the stack.
@@ -67,12 +67,12 @@ All three paths end in the same place: a running stack at [http://localhost:2099
         Go to [http://localhost:2099](http://localhost:2099) and sign up. The first account you create becomes the admin.
       </Step>
       <Step title="Connect a provider">
-        Open the [Routing](http://localhost:2099/routing) page and add an LLM provider (OpenAI, Anthropic, Gemini, etc.) with your API key.
+        Connect a provider and send your first request — see [First request](#first-request).
       </Step>
     </Steps>
 
     <Warning>
-      Before exposing this instance beyond localhost, double-check that `BETTER_AUTH_SECRET` is a real secret (not the placeholder), and if you enable email verification, set `BETTER_AUTH_URL` to a reachable public URL so the verification links resolve.
+      Before exposing this instance beyond localhost, double-check that `BETTER_AUTH_SECRET` is a real random value, and if you enable email verification, set `BETTER_AUTH_URL` to a reachable public URL so the verification links resolve.
     </Warning>
   </Tab>
   <Tab title="Docker Run (BYO PostgreSQL)">
@@ -115,18 +115,48 @@ All three paths end in the same place: a running stack at [http://localhost:2099
   </Tab>
 </Tabs>
 
-## Verify
+## First request
 
-After connecting a provider, send a test request and watch it land in the dashboard. Grab your Manifest API key from the dashboard (it starts with `mnfst_`) and run:
+Signing up leaves you with an empty instance. Three steps to a routed request.
 
-```bash
-curl -X POST http://localhost:2099/v1/chat/completions \
-  -H "Authorization: Bearer mnfst_YOUR_KEY_HERE" \
-  -H "Content-Type: application/json" \
-  -d '{"model": "auto", "messages": [{"role": "user", "content": "Hello"}]}'
-```
+<Steps>
+  <Step title="Connect a provider">
+    In the dashboard sidebar, open **Providers** and pick how you want to connect:
 
-If the response comes back with `That doesn't look like a Manifest key`, you're still using the placeholder — replace `mnfst_YOUR_KEY_HERE` with the real key from the dashboard.
+    - **Usage-based** — paste an API key (OpenAI, Anthropic, Gemini, DeepSeek, …)
+    - **Subscriptions** — reuse a plan you already pay for (ChatGPT, Claude, GLM Coding Plan, …)
+    - **Local** — Ollama, LM Studio, or llama.cpp running on the host
+
+    Manifest discovers the available models as soon as the connection is saved.
+  </Step>
+  <Step title="Copy your agent's key">
+    Every agent has its own key, shown when you create it and again under the agent's **Settings**. It starts with `mnfst_`.
+  </Step>
+  <Step title="Send a request">
+    The endpoint is OpenAI-compatible, so any SDK or agent that accepts a base URL works — point it at `http://localhost:2099/v1` with the `mnfst_` key. To check it end to end:
+
+    ```bash
+    curl -X POST http://localhost:2099/v1/chat/completions \
+      -H "Authorization: Bearer mnfst_YOUR_KEY_HERE" \
+      -H "Content-Type: application/json" \
+      -d '{"model": "auto", "messages": [{"role": "user", "content": "Hello"}]}'
+    ```
+
+    `"model": "auto"` asks Manifest to route the request. Any other name is treated as an explicit choice, and falls back to your routing config if it matches nothing you have connected.
+  </Step>
+</Steps>
+
+The request shows up in the dashboard straight away, with the model that served it and what it cost.
+
+<Note>
+  Errors raised by Manifest itself carry an `M###` code, a plain-English cause, and a link to the matching page under [manifest.build/docs/errors](/errors). The three you are most likely to see on a fresh install:
+
+  | Code | Means |
+  | --- | --- |
+  | `M003` | The token isn't a Manifest key — it doesn't start with `mnfst_` |
+  | `M005` | Well-formed key, but this instance doesn't know it. Copying the literal `mnfst_YOUR_KEY_HERE` above gets you this — replace it with the real key |
+  | `M100` | The key is fine; no provider is connected yet for the model being routed to |
+</Note>
 
 ## Verifying the image signature
 
@@ -140,26 +170,21 @@ cosign verify manifestdotbuild/manifest:<version> \
 
 ## Custom port
 
-If port 2099 is taken, change both the mapping and `BETTER_AUTH_URL`:
+If port 2099 is taken, set `PORT` in `.env`. That is the whole change:
+
+```bash
+PORT=8080
+```
+
+The compose file reads `${PORT:-2099}` for both the published host port and the backend's internal listener, and `BETTER_AUTH_URL` defaults to `http://localhost:${PORT:-2099}` — so one line covers all three, with no YAML edit. The install script writes it for you if you pass `--port 8080`.
+
+For a `docker run` install there is no `.env`, so pass the mapping and the URL explicitly. The container keeps listening on 2099 and Docker remaps it:
 
 ```bash
 docker run -d \
   -p 8080:2099 \
   -e BETTER_AUTH_URL=http://localhost:8080 \
   ...
-```
-
-Or in `docker-compose.yml`:
-
-```yaml
-ports:
-  - '127.0.0.1:8080:2099'
-```
-
-...and in `.env`:
-
-```bash
-BETTER_AUTH_URL=http://localhost:8080
 ```
 
 <Warning>If you see an "Invalid origin" error on the login page, `BETTER_AUTH_URL` doesn't match the URL you're accessing the dashboard on. The host matters as much as the port.</Warning>
@@ -244,14 +269,24 @@ docker compose down -v    # destroys all data
 |----------|----------|---------|-------------|
 | `DATABASE_URL` | Yes | — | PostgreSQL connection string |
 | `BETTER_AUTH_SECRET` | Yes | — | Session signing secret (min 32 chars) |
-| `BETTER_AUTH_URL` | No | `http://localhost:2099` | Public URL. Set this when using a custom port |
-| `PORT` | No | `2099` | Internal server port |
-| `NODE_ENV` | No | `production` | Node environment |
-| `SEED_DATA` | No | `false` | Seed demo data on startup |
+| `MANIFEST_ENCRYPTION_KEY` | Recommended | falls back to `BETTER_AUTH_SECRET` | Separate 32+ char key encrypting stored provider keys and OAuth tokens |
+| `BETTER_AUTH_URL` | No | `http://localhost:${PORT}` | Public URL. Must match the URL in your browser |
+| `PORT` | No | `2099` | Dashboard port — sets the published host port and the internal listener |
+| `MANIFEST_DISABLE_HSTS` | No | unset | Set `1` to silence the boot warning about serving over plain HTTP |
 
-Only the first two are required, and the installer generates both for you, so a default install boots without you setting anything.
+The first two are required and the installer generates both, so a default install boots without you setting anything.
 
-Everything else is optional: bind address and CORS, rate limits, provider timeouts, email delivery for alerts and password resets, OAuth logins, connection-pool sizing, and Sentry. See [Environment variables](/reference/environment-variables) for the full list with defaults.
+<Warning>
+  The installer also generates `MANIFEST_ENCRYPTION_KEY`. If you are installing by hand, set it too. Left unset, Manifest falls back to `BETTER_AUTH_SECRET` for at-rest encryption and warns on every boot — meaning one leaked session-signing secret also decrypts every stored provider key and OAuth token. Set it **before first boot**: introducing it later means re-encrypting what is already in the database.
+</Warning>
+
+Everything else is optional: rate limits, provider timeouts, email delivery for alerts and password resets, OAuth logins, connection-pool sizing, and Sentry. See [Environment variables](/reference/environment-variables) for the full list with defaults.
+
+<Note>
+  `NODE_ENV` and `SEED_DATA` are fixed by the bundled compose file and are not knobs for a self-hosted install. The image is a production artifact, and the demo-data seeder refuses to run under `NODE_ENV=production` whatever `SEED_DATA` says — use the first-run setup wizard to create your admin account.
+
+  `BIND_ADDRESS` is likewise set by the image (`0.0.0.0`, so the container is reachable through Docker's port mapping); restrict exposure with the `ports` line in `docker-compose.yml`, not this variable.
+</Note>
 
 ## Stop and clean up
 
@@ -279,7 +314,7 @@ Once a day, each install sends us a small anonymous report. That's how we know w
 | `manifest_version` | `5.47.0` | Version adoption across the fleet |
 | `messages_total` | `1284` | Daily activity per install |
 | `messages_by_provider` | `{"anthropic": 700, "openai": 500}` | Provider mix. Anything we don't recognize collapses to `"custom"`, so self-hosted provider names and URLs stay local |
-| `messages_by_tier` | `{"default": 900, "batch": 300, ...}` | Routing tier usage |
+| `messages_by_tier` | `{"default": 900, "simple": 300, ...}` | Routing tier usage |
 | `messages_by_auth_type` | `{"api_key": 1200, "subscription": 84}` | API key vs. paid-subscription usage |
 | `tokens_input_total` | `1_450_000` | Volume-weighted signal |
 | `tokens_output_total` | `890_000` | Same |
@@ -315,11 +350,17 @@ The sender checks the flag before doing anything else. No database read, no DNS 
 
 ### Sending it somewhere else
 
-If you'd rather run your own fleet dashboard, point `TELEMETRY_ENDPOINT` at a URL you control:
+If you'd rather run your own fleet dashboard, point `TELEMETRY_ENDPOINT` at a URL you control. Add it to `.env` next to your compose file and restart:
 
 ```bash
 TELEMETRY_ENDPOINT=https://telemetry.mycompany.internal/v1/report
 ```
+
+```bash
+docker compose up -d
+```
+
+Your collector receives the same payload documented above, and nothing is sent to `telemetry.manifest.build`.
 
 ## Docker Hub
 


### PR DESCRIPTION
### 💭 Why
The self-hosted guide sent new users to `http://localhost:2099/routing` twice to connect their first provider. That route does not exist (it lives under `/harnesses/:agent/routing`), and providers moved to their own sidebar section a while back. The single most important step after signup was a dead end.

### ✨ What changed
- Both `/routing` links replaced with a new "First request" section.
- That section covers Providers, the `mnfst_` key, and a curl that works.
- Documented `M003`/`M005`/`M100`, the errors a fresh install actually hits.
- `messages_by_tier` telemetry example used `batch`, which is not a tier.
- Custom port: `PORT` in `.env` does the whole job, no YAML edit.
- Added `MANIFEST_ENCRYPTION_KEY` and `MANIFEST_DISABLE_HSTS` to the tables.
- `NODE_ENV`, `SEED_DATA`, `BIND_ADDRESS`, `CORS_ORIGIN` marked as not self-host knobs.
- Telemetry: say where `TELEMETRY_ENDPOINT` goes and that you restart after.
- Typo: "in your local machine of infrastructure".

### 👤 For users
Following the guide start to finish now gets you to a routed request. Before, it stopped at a 404.

### 📝 Notes
Found by installing from the published docs on a clean machine and following them literally.
Paired with mnfst/manifest#2591, which fixes the installer and compose file behind the same flow.
`mint broken-links` passes.