### PR TITLE
docs: add M102 subscription credentials unusable

### DIFF
--- a/errors.mdx
+++ b/errors.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Errors"
 description: "Reference for every Manifest proxy error code (M001-M500). What you saw, why it happened, and how to fix it. Covers auth, providers, limits, validation."
 icon: "circle-alert"
 keywords:
-  ["Manifest error codes", "M001", "M100", "M200", "M204", "M302", "M500", "OpenAI compatible errors", "401 Unauthorized", "402 Payment Required", "429 Too Many Requests", "Bearer token error", "chat completions error", "model not available", "troubleshooting", "proxy errors"]
+  ["Manifest error codes", "M001", "M100", "M102", "M200", "M204", "M302", "M500", "OpenAI compatible errors", "401 Unauthorized", "402 Payment Required", "429 Too Many Requests", "Bearer token error", "chat completions error", "model not available", "troubleshooting", "proxy errors"]
 ---
 
 When Manifest blocks or rejects a request, the response message starts with a code in square brackets:
@@ -28,14 +28,15 @@ These fire when the bearer token on `/v1/chat/completions` is missing or wrong. 
 | [M004: Key expired](/errors/M004) | Key past its expiration date |
 | [M005: Key not recognized](/errors/M005) | No matching agent for this key |
 
-## Providers (M100–M101)
+## Providers (M100–M102)
 
-Your key is fine, but no provider credentials are wired up. See [Routing](/llm-gateway) and [API key providers](/providers/api-key-providers).
+Your Manifest key is fine, but provider credentials are missing or unusable. See [Routing](/llm-gateway), [API key providers](/providers/api-key-providers), and [Subscription-based providers](/providers/subscription-based-providers).
 
 | Code | What |
 |------|------|
 | [M100: Provider API key missing](/errors/M100) | Routing picked a provider you haven't connected |
 | [M101: No providers configured](/errors/M101) | Agent has zero providers connected |
+| [M102: Provider subscription credentials unusable](/errors/M102) | Subscription OAuth/token exists but cannot be refreshed |
 
 ## Limits (M200–M204)
 

--- a/errors/M100.mdx
+++ b/errors/M100.mdx
@@ -29,6 +29,7 @@ Routing picked a provider that has no key on file for this agent. Manifest won't
 ## Related
 
 - [M101: No providers configured](/errors/M101)
+- [M102: Provider subscription credentials unusable](/errors/M102)
 - [M003: Invalid key format](/errors/M003)
 - [Routing](/llm-gateway)
 - [API key providers](/providers/api-key-providers)

--- a/errors/M101.mdx
+++ b/errors/M101.mdx
@@ -27,6 +27,7 @@ You'll usually see this on a fresh agent. Your key works, but no provider creden
 ## Related
 
 - [M100: Provider API key missing](/errors/M100)
+- [M102: Provider subscription credentials unusable](/errors/M102)
 - [Routing](/llm-gateway)
 - [API key providers](/providers/api-key-providers)
 - [Subscription-based providers](/providers/subscription-based-providers)

--- a/errors/M102.mdx
+++ b/errors/M102.mdx
@@ -1,0 +1,57 @@
+---
+title: "M102: Provider subscription credentials unusable"
+sidebarTitle: "M102"
+description: "Manifest error M102 fires when routing picks a subscription provider whose OAuth or refresh credentials cannot be used. Fix: reconnect the subscription on Routing."
+icon: "plug-zap"
+keywords:
+  [
+    "M102",
+    "Manifest M102",
+    "subscription credentials unusable",
+    "OAuth refresh failed",
+    "ChatGPT OAuth",
+    "Claude subscription",
+    "dead refresh token",
+    "Manifest routing",
+    "reconnect OAuth",
+  ]
+---
+
+## What you saw
+
+```text
+[🦚 Manifest M102] openai subscription credentials could not be refreshed. Reconnect OAuth here: https://app.manifest.build/...
+See https://manifest.build/docs/errors/M102
+```
+
+The provider name (`openai` in the example) varies based on which subscription route Manifest selected.
+
+## Why it happened
+
+Routing elected a **subscription** connection (ChatGPT OAuth, Claude Max token, Copilot device code, and similar), and Manifest still has a stored credential blob for it — but that credential cannot produce a usable access token.
+
+Typical causes:
+
+- The OAuth **refresh token expired**, was revoked, or the user signed out of the provider account
+- A pasted subscription token is no longer valid
+- Provider-side session invalidation after a password change or security reset
+
+This is different from [M100](/errors/M100): M100 means there is no key on file. M102 means a subscription row exists and was elected, but the unwrap/refresh step failed.
+
+When fallback routes are configured, Manifest records the M102 hop and continues the chain. You only see a terminal M102 response when no usable fallback remains.
+
+## How to fix it
+
+1. Open the dashboard link in the error message. It goes straight to the agent's **Routing** page.
+2. On the provider tile, open the **Subscription** tab and reconnect (re-run OAuth, device code, or paste a fresh token).
+3. Optionally add a working [API key](/providers/api-key-providers) or another [subscription](/providers/subscription-based-providers) as a fallback so a dead primary does not block traffic.
+4. Retry the request.
+
+## Related
+
+- [M100: Provider API key missing](/errors/M100)
+- [M101: No providers configured](/errors/M101)
+- [Subscription-based providers](/providers/subscription-based-providers)
+- [API key providers](/providers/api-key-providers)
+- [Routing](/llm-gateway)
+- [All error codes](/errors)


### PR DESCRIPTION
### ✨ What changed
- New `errors/M102.mdx` page for **Provider subscription credentials unusable** (dead/unrefreshable subscription OAuth or token).
- Errors index updated: Providers section is now M100–M102 with an M102 row.
- Cross-links from M100 and M101 related sections.

### 💭 Why
Manifest PR [#2600](https://github.com/mnfst/manifest/pull/2600) introduces M102 when a subscription credential blob exists and is elected, but OAuth unwrap/refresh fails. Public docs should match the peacock message URL (`https://manifest.build/docs/errors/M102`).

### 🔧 How to test
- Preview with `mint dev` and open `/errors/M102` and `/errors`.
- Confirm the sample peacock message matches the backend template for M102.
- Spot-check Related links from M100/M101/M102.

### 📝 Notes
- M102 is distinct from M100 (no key on file vs subscription present but unusable).
- Mentions fallback behavior: M102 is recorded as a hop; terminal only when no usable fallback remains (aligned with PR #2600).