### PR TITLE
docs: document message recording, fix stale privacy claim

### DIFF
--- a/autofix.mdx
+++ b/autofix.mdx
@@ -61,9 +61,16 @@ Self-hosting adds one prerequisite. The per-agent toggle works the same way, but
 | ----------------------------- | ------------- | ------------------------------------------------------ |
 | `AUTOFIX_HEALING_URL`         | unset         | Base URL of the healing service. Unset disables Auto-fix |
 | `AUTOFIX_HEALING_API_KEY`     | unset         | Sent as `x-api-key`. Required by a production healer   |
+| `AUTOFIX_ROLLOUT`             | `selected`    | Set `everyone` to make Auto-fix available to every tenant on the instance |
 | `AUTOFIX_GLOBAL_ENABLED`      | `true`        | Set `false` to disable Auto-fix for every agent at once |
 | `AUTOFIX_TIMEOUT_MS`          | `10000`       | Per heal call                                          |
 | `AUTOFIX_REPAIRABLE_STATUSES` | `400,404,422` | Which statuses are eligible                            |
+
+<Warning>
+  `AUTOFIX_ROLLOUT` gates Auto-fix above the per-agent toggle. Leave it at its
+  default and the toggle won't appear, even with a healing service configured
+  and the agent switched on. Self-hosted instances want `everyone`.
+</Warning>
 
 These are [environment variables](/reference/environment-variables), so they only apply to a Manifest instance you run yourself.
 
@@ -80,6 +87,18 @@ Auto-fix is built to stay out of the way when it isn't working:
 
 Open any request in the dashboard's request log. Requests that went through Auto-fix carry a panel showing what changed and whether the retry succeeded. Only a successful patched retry counts as recovered by Auto-fix.
 
+The failed original and its patched retry are separate [provider attempts](/observability#requests-and-provider-attempts), so with [message recording](/message-recording) on you can read both bodies side by side and see exactly which field was rewritten.
+
+The **Overview** page aggregates the same data across a time range:
+
+| Card | What it measures |
+|---|---|
+| **Request success rate** | Share of requests that ended successfully, however many attempts it took |
+| **Recovered requests** | Share of requests that failed at least one attempt and still succeeded |
+| **Recovered by Auto-fix** | Count of requests where a patched retry is what saved it |
+
+Each card links through to the matching filter on the request log.
+
 <Note>
   When Auto-fix is on, the failing request body is sent to the healing service
   so it can be repaired. Secrets are scrubbed and Manifest stores nothing extra,
@@ -91,5 +110,6 @@ Open any request in the dashboard's request log. Requests that went through Auto
 
 - [LLM Gateway](/llm-gateway) — where Auto-fix sits in the request flow
 - [Observability](/observability) — finding failing requests in the log
+- [Message recording](/message-recording) — reading the original and patched bodies
 - [M302: Model not available](/errors/M302)
 - [Error codes](/errors)

--- a/deploy/fly.mdx
+++ b/deploy/fly.mdx
@@ -72,6 +72,7 @@ fly logs --app <your-fly-app>
 - The template keeps one Machine running so Manifest is always available for agents.
 - For production, choose a larger Postgres configuration or Fly Managed Postgres instead of the small script default.
 - Add a custom domain before configuring OAuth callback URLs.
+- [Message recording](/message-recording) writes to the Machine's local disk by default, which Fly replaces on each deploy. Attach a Fly Volume at `/data/request-recordings`, or point it at S3-compatible storage.
 - Set `MANIFEST_TELEMETRY_DISABLED=1` as a Fly secret if you want to disable anonymous self-hosted telemetry.
 - Destroy both the app and database when testing is done.
 

--- a/deploy/heroku.mdx
+++ b/deploy/heroku.mdx
@@ -71,6 +71,7 @@ heroku logs --tail -a <your-app-name>
 - `PGSSLMODE=no-verify` enables TLS for Heroku Postgres without editing the managed `DATABASE_URL`.
 - `DB_POOL_MAX=8` and `AUTH_DB_POOL_MAX=4` leave headroom under the Essential-0 connection limit.
 - Use a custom domain before configuring production OAuth callbacks.
+- Heroku's filesystem is ephemeral, so [message recording](/message-recording) needs S3-compatible storage. Without it, recordings are lost on every dyno restart.
 
 ## Tearing it down
 

--- a/deploy/koyeb.mdx
+++ b/deploy/koyeb.mdx
@@ -71,6 +71,10 @@ Verify the deployment:
 curl -fsS https://<your-koyeb-domain>/api/v1/health
 ```
 
+## Notes
+
+- Koyeb instances have an ephemeral filesystem, so [message recording](/message-recording) needs S3-compatible storage. Without it, recordings are lost on every redeploy.
+
 ## Tearing it down
 
 Delete both resources when you are done:

--- a/deploy/railway.mdx
+++ b/deploy/railway.mdx
@@ -56,6 +56,7 @@ curl -fsS https://<your-railway-domain>/api/v1/health
 
 - Use a custom domain before configuring production OAuth callbacks.
 - Keep PostgreSQL backups enabled for production data.
+- [Message recording](/message-recording) writes to local disk by default, which Railway discards on redeploy. Point it at S3-compatible storage to keep recordings.
 - Use the Railway service logs when debugging failed boots or database connection issues.
 
 Relevant Railway links:

--- a/deploy/render.mdx
+++ b/deploy/render.mdx
@@ -64,6 +64,7 @@ curl -fsS https://<your-render-service>.onrender.com/api/v1/health
 - Render PostgreSQL connection strings are wired by the Blueprint.
 - Use a custom domain before configuring production OAuth callbacks.
 - If the instance is sleeping on a free plan, the first request can take longer.
+- [Message recording](/message-recording) writes to local disk by default, which Render discards on redeploy. Point it at S3-compatible storage to keep recordings.
 
 Relevant Render docs:
 

--- a/docs.json
+++ b/docs.json
@@ -127,7 +127,7 @@
           {
             "group": "Features",
             "boost": 2,
-            "pages": ["llm-gateway", "autofix", "observability"]
+            "pages": ["llm-gateway", "autofix", "observability", "message-recording"]
           },
           {
             "group": "Providers",

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -26,6 +26,9 @@ You choose which model handles each request. Add fallbacks so a rate limit or a 
   <Card title="Observability" icon="activity" href="/observability">
     See what every agent spent, which models served it, and what failed.
   </Card>
+  <Card title="Message recording" icon="messages-square" href="/message-recording">
+    Read back the full request and response body of any provider attempt, as a conversation.
+  </Card>
 </CardGroup>
 
 ## Cloud or self-hosted?

--- a/message-recording.mdx
+++ b/message-recording.mdx
@@ -1,0 +1,105 @@
+---
+title: "Message recording"
+description: "Store the full request and response body of every provider attempt, and read them back as a conversation in the request drawer. One toggle per agent."
+icon: "messages-square"
+keywords:
+  ["message recording", "request body", "response body", "LLM conversation log", "prompt logging", "full body log", "tool calls", "recording retention", "S3 recording storage"]
+---
+
+The [request log](/observability) tells you what a request cost and which model served it. Message recording tells you what was actually said: the body Manifest sent to the provider, and the body that came back.
+
+It's one toggle per agent.
+
+## What gets recorded
+
+Recording happens per **provider attempt**, not per request. A request that falls back twice before succeeding produces three recordings, each with its own body pair, so you can see how the conversation was reshaped for each provider. An [Auto-fix](/autofix) retry is its own attempt too, which is how you compare the request that failed against the patched one that worked.
+
+| | What's stored |
+|---|---|
+| **Request** | The body Manifest forwarded to the provider, after routing rewrote the model and translated the protocol. Not the body your client sent |
+| **Response** | The parsed JSON body, or for a streamed attempt, the raw SSE stream as it arrived |
+| **Wire format** | Which protocol the exchange used, so the drawer can render it correctly |
+
+A request Manifest blocked itself, on a [hard limit](/llm-gateway#hard-limits) or a malformed body, has zero provider attempts and so no recording. There was no exchange to record.
+
+## Reading it back
+
+Open any request in the dashboard's **Requests** log. When recordings exist, the drawer has a **Messages** tab next to **Attempts**.
+
+The tab renders the exchange as a conversation, with a rail down the side listing every turn. Search the rail or filter it by role, and click any row to jump to that turn in the main pane. Assistant turns show the tool calls the model actually made, not the tool definitions your client offered it.
+
+## Turning it on
+
+The toggle lives on each agent's **Settings** page, under **Message recording**.
+
+New agents have it on. Older agents keep whatever they were set to, because only the default changed, so an agent from before the feature shipped probably needs the toggle flipped once.
+
+<Note>
+  Recording stores your prompts and completions. Everything else Manifest keeps
+  is metadata ([Data and telemetry](/reference/telemetry) covers the
+  distinction). If an agent handles data you'd rather Manifest never hold onto,
+  leave recording off for that agent.
+</Note>
+
+## Retention
+
+Recordings are deleted on a schedule. The metadata row in the request log stays; only the stored body pair goes away.
+
+| Deployment | Retention |
+|---|---|
+| Cloud Free | 7 days |
+| Cloud Pro | 365 days |
+| Self-hosted | 365 days |
+
+Self-hosted installs can override this with `REQUEST_RECORDING_RETENTION_DAYS`. Setting it also overrides the per-plan split, so every recording on the instance expires on the same schedule.
+
+## Self-hosted storage
+
+Recordings don't live in Postgres. They're gzipped and written to object storage, which you pick per instance.
+
+<Tabs>
+  <Tab title="Docker (default)">
+    The bundled compose file mounts a named volume `manifest_request_recordings`
+    at `/data/request-recordings` and points Manifest at it. Nothing to
+    configure. The volume survives `docker compose down` the same way the
+    Postgres volume does.
+  </Tab>
+  <Tab title="S3-compatible">
+    Set a bucket and region, and Manifest writes there instead. Required for
+    multi-replica deploys, since replicas can't share a local disk, and for any
+    platform without a persistent volume.
+
+    ```bash
+    REQUEST_RECORDING_S3_BUCKET=manifest-recordings
+    REQUEST_RECORDING_S3_REGION=auto
+    REQUEST_RECORDING_S3_ENDPOINT=https://<account>.r2.cloudflarestorage.com
+    REQUEST_RECORDING_S3_ACCESS_KEY_ID=...
+    REQUEST_RECORDING_S3_SECRET_ACCESS_KEY=...
+    ```
+
+    Credentials are optional if the instance already has them from its
+    environment (an IAM role, for example). Provide both or neither.
+  </Tab>
+</Tabs>
+
+`REQUEST_RECORDING_STORAGE` defaults to `auto`, which picks the backend by what you've configured: any S3 setting present means S3, otherwise the mounted filesystem path. Set it to `s3`, `filesystem`, or `disabled` to decide explicitly.
+
+<Warning>
+  Under `auto`, setting *some* S3 variables commits Manifest to S3. A bucket
+  without a region, or one access-key half without the other, leaves recording
+  with no working backend instead of falling back to local disk. Configure it
+  fully or not at all.
+</Warning>
+
+Full variable list: [Environment variables](/reference/environment-variables#request-recordings).
+
+### Platforms without a persistent disk
+
+Railway, Render, Fly, Heroku, and Koyeb all give you an ephemeral filesystem, so local recordings there are wiped on every redeploy and every container restart. Point those deploys at S3-compatible storage, or accept that recordings only survive until the next deploy.
+
+## Related
+
+- [Observability](/observability) — the request log these recordings hang off
+- [Auto-fix](/autofix) — comparing a failed request against its patched retry
+- [Data and telemetry](/reference/telemetry) — what Manifest stores by default
+- [Environment variables](/reference/environment-variables#request-recordings)

--- a/observability.mdx
+++ b/observability.mdx
@@ -42,6 +42,8 @@ This is why the request count and the provider call count don't match, and why c
 
 Opening a request in the log shows the whole story: the tier that routed it, the model and provider that served it, input and output tokens, computed cost, latency, the auth type used ([API key, subscription, or local](/reference/glossary#auth-type)), and every fallback hop with its own status. Failures carry an error code, so a Manifest rejection like [M100](/errors/M100) reads differently from a provider's own 500.
 
+That's all metadata. To read the messages themselves, turn on [message recording](/message-recording) for the agent. The drawer picks up a **Messages** tab next to **Attempts**, with the body sent to the provider and the body that came back.
+
 <Tip>
   Local models record `cost = 0` with real token counts and latency, since
   nothing was billed. Custom providers do the same, because Manifest can't
@@ -118,6 +120,7 @@ Separately from your dashboard, each self-hosted install sends a small daily rep
 ## Related
 
 - [LLM Gateway](/llm-gateway) — routing, fallback, and hard limits
+- [Message recording](/message-recording) — the request and response bodies
 - [Auto-fix](/autofix)
 - [Error codes](/errors)
 - [Glossary](/reference/glossary)

--- a/providers/api-key-providers.mdx
+++ b/providers/api-key-providers.mdx
@@ -1,10 +1,10 @@
 ---
 title: "API key providers"
 sidebarTitle: "API keys"
-description: "Bring your own API key for OpenAI, Anthropic, Google, xAI, DeepSeek, Mistral, Groq, Cerebras, AWS Bedrock, NVIDIA NIM, OpenRouter, and more."
+description: "Bring your own API key for OpenAI, Anthropic, Google, xAI, DeepSeek, Mistral, Groq, Cerebras, AWS Bedrock, NVIDIA NIM, OpenRouter, Hugging Face, and more."
 icon: "key"
 keywords:
-  ["OpenAI", "Anthropic", "Google Gemini", "xAI", "DeepSeek", "Mistral", "Qwen", "Moonshot", "MiniMax", "Z.ai", "OpenRouter", "Groq", "Cerebras", "Fireworks", "AWS Bedrock", "NVIDIA NIM", "Xiaomi MiMo", "API key"]
+  ["OpenAI", "Anthropic", "Google Gemini", "xAI", "DeepSeek", "Mistral", "Qwen", "Moonshot", "MiniMax", "Z.ai", "OpenRouter", "Groq", "Cerebras", "Fireworks", "AWS Bedrock", "NVIDIA NIM", "Xiaomi MiMo", "Hugging Face", "Gemini Free", "API key"]
 ---
 
 Most providers work the standard way: sign up, generate an API key, paste it into Manifest. Routed requests go out with that key as the credential.
@@ -33,8 +33,13 @@ Most providers work the standard way: sign up, generate an API key, paste it int
 | [Xiaomi MiMo](https://platform.xiaomimimo.com)    | [platform.xiaomimimo.com](https://platform.xiaomimimo.com/console/api-keys) |
 | [Kilo](https://kilo.ai)                           | [app.kilo.ai](https://app.kilo.ai)                               |
 | [Pioneer](https://pioneer.ai)                     | [pioneer.ai](https://pioneer.ai)                                 |
+| [Hugging Face](https://huggingface.co)            | [huggingface.co/settings/tokens](https://huggingface.co/settings/tokens) |
 
 New providers are added often, so the **Routing** page always shows the current list of tiles.
+
+### Gemini Free
+
+Gemini Free is a managed tile. Manifest provisions the credential through its own gateway, so there's no key to fetch from Google first: add the tile and you have a free model to route to. It behaves like any other provider once connected.
 
 <Note>
   BytePlus, NousResearch, Command Code, ClinePass, Kiro, GitHub Copilot, Ollama
@@ -80,6 +85,7 @@ Each provider issues keys with a recognizable prefix. Useful for catching paste 
 | Groq       | `gsk_`    | `gsk_...`    |
 | Pioneer    | `pio_sk_` | `pio_sk_...` |
 | Xiaomi MiMo | `sk-`    | `sk-...`     |
+| Hugging Face | `hf_`   | `hf_...`     |
 
 Providers not listed here (Cerebras, NVIDIA NIM, AWS Bedrock, Kilo, OpenCode Zen) issue keys with no fixed prefix.
 

--- a/reference/environment-variables.mdx
+++ b/reference/environment-variables.mdx
@@ -56,6 +56,41 @@ How Manifest talks to upstream providers.
 | `STREAM_WARMUP_MS` | `15000` | How long to wait for the first streamed chunk before falling back to the next model |
 | `OLLAMA_HOST` | `http://localhost:11434` | Base URL for a local Ollama server. In Docker, set it to `http://host.docker.internal:11434` |
 
+## Request recordings
+
+Storage and retention for [message recording](/message-recording). The bundled Docker setup already sets the filesystem path and mounts a volume for it, so a default install needs none of these.
+
+| Variable | Default | Description |
+|---|---|---|
+| `REQUEST_RECORDING_STORAGE` | `auto` | `auto`, `s3`, `filesystem`, or `disabled`. Under `auto`, any S3 variable being set selects S3; otherwise the filesystem path is used |
+| `REQUEST_RECORDING_FILESYSTEM_PATH` | `/data/request-recordings` | Where recordings are written on disk. Must be a persistent volume |
+| `REQUEST_RECORDING_RETENTION_DAYS` | `365` | Days to keep recordings before the sweep deletes them |
+| `REQUEST_RECORDING_S3_BUCKET` | — | Bucket name. Required for S3 |
+| `REQUEST_RECORDING_S3_REGION` | — | Region. Use `auto` for R2 and similar. Required for S3 |
+| `REQUEST_RECORDING_S3_ENDPOINT` | — | Custom endpoint for non-AWS S3-compatible storage |
+| `REQUEST_RECORDING_S3_ACCESS_KEY_ID` | — | Access key. Omit both key variables to use ambient credentials |
+| `REQUEST_RECORDING_S3_SECRET_ACCESS_KEY` | — | Secret key. Must be set together with the access key ID |
+| `REQUEST_RECORDING_S3_FORCE_PATH_STYLE` | `false` | Set `true` for storage that needs path-style bucket addressing (MinIO) |
+
+<Warning>
+  A partial S3 configuration disables recording rather than falling back to
+  local disk. Set bucket **and** region, and either both access-key variables or
+  neither.
+</Warning>
+
+## Auto-fix
+
+[Auto-fix](/autofix) needs a healing service to talk to. Without `AUTOFIX_HEALING_URL` it stays inert and never touches your traffic.
+
+| Variable | Default | Description |
+|---|---|---|
+| `AUTOFIX_HEALING_URL` | unset | Base URL of the healing service. Unset disables Auto-fix |
+| `AUTOFIX_HEALING_API_KEY` | unset | Sent as `x-api-key`. Required by a production healer |
+| `AUTOFIX_ROLLOUT` | `selected` | Set `everyone` to make Auto-fix available to every tenant on the instance |
+| `AUTOFIX_GLOBAL_ENABLED` | `true` | Set `false` to disable Auto-fix for every agent at once |
+| `AUTOFIX_TIMEOUT_MS` | `10000` | Per heal call |
+| `AUTOFIX_REPAIRABLE_STATUSES` | `400,404,422` | Which statuses are eligible |
+
 ## Email
 
 Used for both Better Auth transactional emails (signup verification, password reset) **and** [threshold alerts](/observability#spend-alerts). Set one provider block.

--- a/reference/telemetry.mdx
+++ b/reference/telemetry.mdx
@@ -1,19 +1,27 @@
 ---
 title: "Data and telemetry"
 sidebarTitle: "Data & telemetry"
-description: "What Manifest stores about your requests, what it never stores, and the anonymous daily report each self-hosted install sends. Includes the full field list and how to opt out."
+description: "What Manifest stores about your requests, what's optional, and the anonymous daily report each self-hosted install sends. Includes the full field list and how to opt out."
 icon: "shield"
 keywords:
-  ["data privacy", "prompt storage", "anonymous telemetry", "MANIFEST_TELEMETRY_DISABLED", "TELEMETRY_ENDPOINT", "install_id", "opt out", "self-hosted telemetry"]
+  ["data privacy", "prompt storage", "message recording", "anonymous telemetry", "MANIFEST_TELEMETRY_DISABLED", "TELEMETRY_ENDPOINT", "install_id", "opt out", "self-hosted telemetry"]
 ---
 
 Two separate things happen to data as requests flow through Manifest: what your own instance records for the dashboard, and what a self-hosted install reports back to the project. This page covers both.
 
 ## What Manifest stores
 
-Manifest keeps metadata about each request: model, provider, tier, token counts, cost, latency, and a scrubbed error message. It does not keep the message bodies. Prompts and completions are never written to the database, inline image data is stripped out, and error text is scrubbed for secrets before it lands.
+Manifest always keeps metadata about each request: model, provider, tier, token counts, cost, latency, and a scrubbed error message. Inline image data is stripped out, and error text is scrubbed for secrets before it lands. The usage and cost views in the dashboard are built from that metadata alone. See [Observability](/observability) for what the record looks like in practice.
 
-Your agents' conversations stay between you and the provider. The usage and cost views in the dashboard are built from that metadata alone. See [Observability](/observability) for what that record looks like in practice.
+Message bodies are separate, and optional. With [message recording](/message-recording) on for an agent, Manifest also stores the request and response bodies of each provider attempt so you can read them back in the dashboard. New agents have it enabled; agents created before the feature shipped keep whatever they were set to.
+
+Recorded bodies are held outside the database, in the object storage your instance is configured for, and deleted on a retention schedule. With recording off for an agent, that agent's prompts and completions stay between you and the provider, exactly as before.
+
+<Note>
+  If an agent handles data you'd rather Manifest never hold onto, turn message
+  recording off on its **Settings** page. Metadata collection isn't affected
+  either way.
+</Note>
 
 ## Anonymous telemetry
 

--- a/self-hosted.mdx
+++ b/self-hosted.mdx
@@ -216,7 +216,14 @@ Database migrations run automatically on boot, no manual steps. Your data in the
 
 ## Backup and persistence
 
-All state lives in the `pgdata` named volume mounted at `/var/lib/postgresql/data` in the `postgres` service. Nothing else in the Manifest container is stateful.
+The stack uses two named volumes:
+
+| Volume | Mounted at | Holds |
+|---|---|---|
+| `manifest_pgdata` | `/var/lib/postgresql/data` in `postgres` | Everything: accounts, agents, provider credentials, the request log |
+| `manifest_request_recordings` | `/data/request-recordings` in `manifest` | Stored [message recording](/message-recording) bodies |
+
+The database volume is the one to back up. Losing the recordings volume costs you stored message bodies and nothing else, and those expire on a retention schedule regardless.
 
 Back up (from the host, with the stack running):
 
@@ -235,7 +242,7 @@ docker compose up -d
 To list or remove the volume manually:
 
 ```bash
-docker volume ls | grep pgdata
+docker volume ls | grep manifest_
 docker compose down -v    # destroys all data
 ```
 
@@ -254,7 +261,7 @@ docker compose down -v    # destroys all data
 
 Only the first two are required, and the installer generates both for you, so a default install boots without you setting anything.
 
-Everything else is optional: bind address and CORS, rate limits, provider timeouts, email delivery for alerts and password resets, OAuth logins, connection-pool sizing, and Sentry. See [Environment variables](/reference/environment-variables) for the full list with defaults.
+Everything else is optional: bind address and CORS, rate limits, provider timeouts, email delivery for alerts and password resets, OAuth logins, connection-pool sizing, recording storage and retention, Auto-fix, and Sentry. See [Environment variables](/reference/environment-variables) for the full list with defaults.
 
 ## Stop and clean up
 
@@ -265,7 +272,7 @@ docker compose down -v    # Stop and delete all data
 
 ## Data and privacy
 
-Manifest keeps metadata about each request — model, provider, tier, token counts, cost, latency — and never the message bodies. Prompts and completions are not written to the database.
+Manifest always keeps metadata about each request — model, provider, tier, token counts, cost, latency. Message bodies are separate and optional: with [message recording](/message-recording) on for an agent, prompts and completions are stored too, in the recordings volume rather than the database. New agents have it enabled. See [Data and telemetry](/reference/telemetry).
 
 ## Telemetry
 


### PR DESCRIPTION
### 💭 Why
Message recording shipped in mnfst/manifest#2565 with no docs at all. Worse, two pages still told people Manifest never stores message bodies. It does now, whenever the toggle is on, and that toggle defaults to on for new agents.

### ✨ What changed
- New `message-recording.mdx`: what's stored per provider attempt, the Messages tab, retention, storage backends.
- `reference/telemetry.mdx` and `self-hosted.mdx` no longer claim prompts are never stored.
- Added the 9 `REQUEST_RECORDING_*` and 6 `AUTOFIX_*` variables to the env reference. Neither group was there.
- `AUTOFIX_ROLLOUT` documented with a warning: at its default the toggle never appears, even with a healer configured.
- Documented the Auto-fix cards on the Overview page.
- `self-hosted.mdx` backup section said all state lives in pgdata. There are two volumes now.
- Railway, Render, Fly, Heroku, Koyeb each warn that local recordings die on redeploy.
- Added Hugging Face and Gemini Free to the provider list.

### 👤 For users
Retention is 7 days on Cloud Free, 365 on Pro and self-hosted. Agents created before the feature shipped keep recording off until you flip it, which the page now says.

### 🔧 For operators
Self-hosters on a platform without a persistent disk need S3, or recordings vanish on every deploy. A half-configured S3 setup disables recording rather than falling back to disk, so that trap is called out in both the page and the env reference.

### 📝 Notes
Source: mnfst/manifest at 73d58c63a.
n8n and Apple Containers are also undocumented. Left out of this PR, both need more than a paragraph.