### PR TITLE
docs: drop Dashboard and Book a call from the sidebar bottom

### DIFF
--- a/style.css
+++ b/style.css
@@ -28,6 +28,13 @@ a[href="https://manifest.build"] img {
   --tw-bg-opacity: 1;
 }
 
+/* Sidebar bottom links: Book a call is already top right and Dashboard is in
+   the footer, so only GitHub and Discord stay */
+#sidebar li[id="https://app.manifest.build"],
+#sidebar li[id="https://calendly.com/sebastien-manifest/30min"] {
+  display: none;
+}
+
 /* Accent color on anchor links */
 .nav-anchor {
   border-color: #0f172a;


### PR DESCRIPTION
The maple theme repeats the navbar links at the bottom of the sidebar. Book a call is already fixed top right and Dashboard lives in the footer, so both are hidden there via CSS, targeted by their exact URLs. GitHub and Discord stay.

No change to `docs.json`: removing the entries from `navbar.links`/`navbar.primary` would also remove them from the top bar and footer.
