### PR TITLE
docs: Responses conversation state is the client's job (issue #79)

### DIFF
--- a/reference/api.mdx
+++ b/reference/api.mdx
@@ -36,6 +36,8 @@ Generate a key from the dashboard's **Harnesses** page. Keys always start with `
 
 The proxy translates between formats internally, so you can send an OpenAI-shaped request and Manifest will reshape it before forwarding to an Anthropic-only model. The reverse works too.
 
+Translation carries what the request itself contains: messages, tools, and tool results. Manifest does not resolve `previous_response_id`, so send the full conversation in `input` on every `/v1/responses` request.
+
 ## Chat completions
 
 ```bash


### PR DESCRIPTION
Processes the single finding of #79, option 1, verified against mnfst/manifest main at 061d351f5.

Two sentences under the endpoints table. Translation carries messages, tools, and tool results. Manifest never reads `previous_response_id` (one repo-wide hit, an output field hardcoded to `null`) and stores no Responses state, so a threading client must resend the full conversation in `input` on every request. True on every route, native or translated, so the sentence needs no case split.

The companion finding on the same page (#68 finding 5, the verbatim-forwarding claim) already shipped in PR #74.

Coherence GREEN (48 pages, 57 vars).

Closes #79