### PR TITLE
docs: gateway routing and fallback boundaries (issues #82, #84)

### DIFF
--- a/llm-gateway.mdx
+++ b/llm-gateway.mdx
@@ -18,7 +18,7 @@ Point your client at Manifest instead of a provider, and every request goes thro
     If a hard limit for this harness is already over its threshold, the request is blocked with [M200](/errors/M200) before any provider is called. Nothing is spent.
   </Step>
   <Step title="Routing">
-    A custom tier matches on a request header, or the request goes to your default tier. Send a real model ID instead of `auto` to skip this entirely.
+    A custom tier matches on a request header, or the request goes to your default tier. Send a real model ID instead of `auto` to skip routing. A matching custom tier header still wins.
   </Step>
   <Step title="Forward">
     Manifest calls the resolved provider with your credentials and streams the response back.
@@ -72,7 +72,7 @@ Create as many tiers as you need, each with its own model and parameters. This i
 
 ### Route a specific model
 
-To skip routing for a single request, send a real model ID instead of `auto`. Manifest forwards it straight to that model's provider, with no tier lookup and no fallbacks. Call [`GET /v1/models`](/reference/api#listing-models) to list the model IDs your harness can reach.
+To skip routing for a single request, send a real model ID instead of `auto`. Manifest forwards it straight to that model's provider, with no tier lookup and no fallbacks. A matching [custom tier](#custom-tiers) header is the exception. The request then runs on the tier's model and the tier's fallbacks. Call [`GET /v1/models`](/reference/api#listing-models) to list the model IDs your harness can reach.
 
 ```bash
 curl -X POST https://app.manifest.build/v1/chat/completions \
@@ -106,6 +106,10 @@ Any HTTP status code **>= 400** triggers a fallback.
 | **502** | Bad gateway |
 | **503** | Service unavailable |
 | **529** | Provider overloaded |
+
+An upstream 429 also pauses that model for a short time. When the provider sends a `Retry-After`, that value sets the pause, up to five minutes. During the pause, Manifest sends the request to the next model in the chain. A request with no chain behind it, such as a direct model ID, comes back as a 429 that the provider never sent.
+
+Fallback covers a streaming request until the first chunk reaches your client. If the stream fails after that, the error arrives inside the stream and the connection closes. Manifest tries no other model.
 
 ### Configuration
 

--- a/llm-gateway.mdx
+++ b/llm-gateway.mdx
@@ -107,11 +107,7 @@ Any HTTP status code **>= 400** triggers a fallback.
 | **503** | Service unavailable |
 | **529** | Provider overloaded |
 
-After a provider answers 429, Manifest pauses that model for a short time, a few minutes at most. A routed request moves to the next model in the chain. A direct model ID has no chain, so it comes back with a 429 that the provider never sent.
-
-A tier also falls back when its pinned model leaves your model list. No provider error is involved and no response header marks the change: the tier's first available fallback serves the request, at its own price. A tier with no fallback left returns [M101](/errors/M101). The **Routing** page still shows the old model name, so open the model picker and pin a new one.
-
-Fallback covers a streaming request until the first chunk reaches your client. If the stream fails after that, the error arrives inside the stream and the connection closes. Manifest tries no other model.
+A tier also falls back when its pinned model leaves your model list. When the tier has no fallback left, the request returns [M101](/errors/M101).
 
 ### Configuration
 

--- a/llm-gateway.mdx
+++ b/llm-gateway.mdx
@@ -109,6 +109,10 @@ Any HTTP status code **>= 400** triggers a fallback.
 
 An upstream 429 also pauses that model for a short time. When the provider sends a `Retry-After`, that value sets the pause, up to five minutes. During the pause, Manifest sends the request to the next model in the chain. A request with no chain behind it, such as a direct model ID, comes back as a 429 that the provider never sent.
 
+A tier also moves to its fallback list when its pinned model leaves your model list, and no provider error is involved. Your provider can retire the model. Manifest can also drop it when its capability data does not report tool calling. A model that data does not cover at all is kept. Manifest then serves the request with the first fallback model in that tier whose provider is still connected, at that model's price. No response header marks this, because `X-Manifest-Fallback-From` is only set after a failed attempt. A tier with no usable fallback left returns [M101](/errors/M101), whose message says no providers are set up.
+
+The tier card on the **Routing** page keeps showing the old model name. The model picker no longer lists that model, so pin a different one.
+
 Fallback covers a streaming request until the first chunk reaches your client. If the stream fails after that, the error arrives inside the stream and the connection closes. Manifest tries no other model.
 
 ### Configuration

--- a/llm-gateway.mdx
+++ b/llm-gateway.mdx
@@ -107,11 +107,9 @@ Any HTTP status code **>= 400** triggers a fallback.
 | **503** | Service unavailable |
 | **529** | Provider overloaded |
 
-An upstream 429 also pauses that model for a short time. When the provider sends a `Retry-After`, that value sets the pause, up to five minutes. During the pause, Manifest sends the request to the next model in the chain. A request with no chain behind it, such as a direct model ID, comes back as a 429 that the provider never sent.
+After a provider answers 429, Manifest pauses that model for a short time, a few minutes at most. A routed request moves to the next model in the chain. A direct model ID has no chain, so it comes back with a 429 that the provider never sent.
 
-A tier also moves to its fallback list when its pinned model leaves your model list, and no provider error is involved. Your provider can retire the model. Manifest can also drop it when its capability data does not report tool calling. A model that data does not cover at all is kept. Manifest then serves the request with the first fallback model in that tier whose provider is still connected, at that model's price. No response header marks this, because `X-Manifest-Fallback-From` is only set after a failed attempt. A tier with no usable fallback left returns [M101](/errors/M101), whose message says no providers are set up.
-
-The tier card on the **Routing** page keeps showing the old model name. The model picker no longer lists that model, so pin a different one.
+A tier also falls back when its pinned model leaves your model list. No provider error is involved and no response header marks the change: the tier's first available fallback serves the request, at its own price. A tier with no fallback left returns [M101](/errors/M101). The **Routing** page still shows the old model name, so open the model picker and pin a new one.
 
 Fallback covers a streaming request until the first chunk reaches your client. If the stream fails after that, the error arrives inside the stream and the connection closes. Manifest tries no other model.
 


### PR DESCRIPTION
Processes finding 1 of #82 and, reduced to its two useful facts, finding 1 of #84. Findings 2 and 4 of #82 were rejected on review.

**Issue #82, finding 1 (option 1)** — the page promised twice that naming a model skips routing, while the Custom tiers section states the header wins. Both promises now carry the exception: the Routing step gets one sentence, and Route a specific model states that a matching custom tier header runs the request on the tier's model and the tier's fallbacks.

**Issue #84, finding 1 (trimmed)** — one sentence under the status table: a tier also falls back when its pinned model leaves your model list, and a tier with no fallback left returns M101.

The 429-pause and streaming-boundary paragraphs were dropped on review: no fact the reader acts on.

Coherence GREEN.

Closes #82
Closes #84
